### PR TITLE
[JENKINS-44487] Added the ability to use a URL in cfnUpdate

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ The step returns the outputs of the stack as a map.
 def outputs = cfnUpdate(stack:'my-stack', file:'template.yaml', params:['InstanceType=t2.nano'], keepParams:['Version'], timeoutInMinutes:10, tags:['TagName=Value'])
 ```
 
+Alternatively, you can specify a URL to a template on S3 (you'll need this if you hit the 51200 byte limit on template):
+
+```
+def outputs = cfnUpdate(stack:'my-stack', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml')
+```
+
+Note: When creating a stack, either `file` or `url` are required. When updating it, omitting both parameters will keep the stack's current template.
+
 ## cfnDelete
 
 Remove the given stack from CloudFormation.

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
@@ -172,7 +172,6 @@ public class CFNUpdateStep extends AbstractStepImpl {
 			final Integer timeoutInMinutes = this.step.getTimeoutInMinutes();
 
 			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
-			Preconditions.checkArgument((file != null && !file.isEmpty()) || (url != null && !url.isEmpty()), "Either file or url must be specified");
 			
 			this.listener.getLogger().format("Updating/Creating CloudFormation stack %s %n", stack);
 			

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
@@ -172,6 +172,7 @@ public class CFNUpdateStep extends AbstractStepImpl {
 			final Integer timeoutInMinutes = this.step.getTimeoutInMinutes();
 
 			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
+			Preconditions.checkArgument((file != null && !file.isEmpty()) || (url != null && !url.isEmpty()), "Either file or url must be specified");
 			
 			this.listener.getLogger().format("Updating/Creating CloudFormation stack %s %n", stack);
 			

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -73,6 +73,10 @@ public class CloudFormationStack {
 	}
 	
 	public void create(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, Integer timeoutInMinutes) throws ExecutionException {
+		if ((templateBody != null && !templateBody.isEmpty()) || (templateUrl != null && !templateUrl.isEmpty())) {
+			throw new IllegalArgumentException("Either a file or url for the template must be specified");
+		}
+		
 		CreateStackRequest req = new CreateStackRequest();
 		req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM);
 		req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags).withTimeoutInMinutes(timeoutInMinutes);
@@ -85,7 +89,17 @@ public class CloudFormationStack {
 		try {
 			UpdateStackRequest req = new UpdateStackRequest();
 			req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM);
-			req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags);
+			
+			if (templateBody != null && !templateBody.isEmpty()) {
+				req.setTemplateBody(templateBody);
+			} else if (templateUrl != null && !templateUrl.isEmpty()) {
+				req.setTemplateURL(templateUrl);
+			} else {
+				req.setUsePreviousTemplate(true);
+			}
+			
+			req.withParameters(params).withTags(tags);
+			
 			this.client.updateStack(req);
 			
 			new EventPrinter(this.client, this.listener).waitAndPrintStackEvents(this.stack, this.client.waiters().stackUpdateComplete());

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -72,20 +72,20 @@ public class CloudFormationStack {
 		return map;
 	}
 	
-	public void create(String templateBody, Collection<Parameter> params, Collection<Tag> tags, Integer timeoutInMinutes) throws ExecutionException {
+	public void create(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, Integer timeoutInMinutes) throws ExecutionException {
 		CreateStackRequest req = new CreateStackRequest();
 		req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM);
-		req.withTemplateBody(templateBody).withParameters(params).withTags(tags).withTimeoutInMinutes(timeoutInMinutes);
+		req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags).withTimeoutInMinutes(timeoutInMinutes);
 		this.client.createStack(req);
 		
 		new EventPrinter(this.client, this.listener).waitAndPrintStackEvents(this.stack, this.client.waiters().stackCreateComplete());
 	}
 	
-	public void update(String templateBody, Collection<Parameter> params, Collection<Tag> tags) throws ExecutionException {
+	public void update(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags) throws ExecutionException {
 		try {
 			UpdateStackRequest req = new UpdateStackRequest();
 			req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM);
-			req.withTemplateBody(templateBody).withParameters(params).withTags(tags);
+			req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags);
 			this.client.updateStack(req);
 			
 			new EventPrinter(this.client, this.listener).waitAndPrintStackEvents(this.stack, this.client.waiters().stackUpdateComplete());


### PR DESCRIPTION
[CloudFormation's limits](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html) require that we upload the template to S3 and run create-stack or update-stack with a reference there using the template-url parameter. It would be great if this was supported by cfnUpdate.

https://issues.jenkins-ci.org/browse/JENKINS-44487