### PR TITLE
Pipeline syntax generator visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Upload a file/folder from the workspace to an S3 bucket.
 If the `file` parameter denotes a directory, the complete directory including all subfolders will be uploaded.
 
 ```
-s3Upload(file:'file.txt', bucket:'my-bucket', path:'/path/to/target/file.txt')
-s3Upload(file:'someFolder', bucket:'my-bucket', path:'/path/to/targetFolder/')
+s3Upload(file:'file.txt', bucket:'my-bucket', path:'path/to/target/file.txt')
+s3Upload(file:'someFolder', bucket:'my-bucket', path:'path/to/targetFolder/')
 ```
 
 ## s3Download
@@ -87,8 +87,8 @@ Set optional parameter `force` to `true` to overwrite existing file in workspace
 If the `path` ends with a `/` the complete virtual directory will be downloaded.
 
 ```
-s3Download(file:'file.txt', bucket:'my-bucket', path:'/path/to/source/file.txt', force:true)
-s3Download(file:'targetFolder/', bucket:'my-bucket', path:'/path/to/sourceFolder/', force:true)
+s3Download(file:'file.txt', bucket:'my-bucket', path:'path/to/source/file.txt', force:true)
+s3Download(file:'targetFolder/', bucket:'my-bucket', path:'path/to/sourceFolder/', force:true)
 ```
 
 ## cfnValidate

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -57,12 +57,12 @@ import jenkins.model.Jenkins;
 
 public class WithAWSStep extends AbstractStepImpl {
 	
-	private String role;
-	private String roleAccount;
-	private String region;
-	private String profile;
-	private String credentials;
-	private String externalId;
+	private String role = "";
+	private String roleAccount = "";
+	private String region = "";
+	private String profile = "";
+	private String credentials = "";
+	private String externalId = "";
 
 	@DataBoundConstructor
 	public WithAWSStep() {

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -206,8 +206,10 @@ public class WithAWSStep extends AbstractStepImpl {
 				
 				AssumeRoleRequest request = new AssumeRoleRequest()
 						.withRoleArn(roleARN)
-						.withRoleSessionName(this.createRoleSessionName())
-						.withExternalId(this.step.getExternalId());
+						.withRoleSessionName(this.createRoleSessionName());
+				if(!StringUtils.isNullOrEmpty(this.step.getExternalId())) {
+					request.withExternalId(this.step.getExternalId());
+				}
 
 				AssumeRoleResult assumeRole = sts.assumeRole(request);
 				

--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/config.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%File}" field="file">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Bucket}" field="bucket">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Path}" field="path">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Force}" field="force">
+		<f:checkbox default="false" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-bucket.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-bucket.html
@@ -1,0 +1,3 @@
+<div>
+	This is the bucket to use.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-file.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-file.html
@@ -1,0 +1,3 @@
+<div>
+	This is the local file to upload from the workspace.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-force.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-force.html
@@ -1,0 +1,3 @@
+<div>
+	Set this to true to overwrite local workspace files.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-path.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-path.html
@@ -1,0 +1,4 @@
+<div>
+	This is the path to use.
+	<i>Do not begin with a leading "/".</i>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help.html
@@ -1,0 +1,7 @@
+<div>
+	<p>
+		Download a file/folder from S3 to the local workspace.
+		Set optional parameter <tt>force</tt> to true to overwrite any existing files in workspace.
+		If the path ends with a <tt>/</tt>, then the complete virtual directory will be downloaded.
+	</p>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%File}" field="file">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Bucket}" field="bucket">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Path}" field="path">
+		<f:textbox />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-bucket.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-bucket.html
@@ -1,0 +1,3 @@
+<div>
+	This is the bucket to use.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-file.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-file.html
@@ -1,0 +1,3 @@
+<div>
+	This is the local file to upload from the workspace.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-path.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-path.html
@@ -1,0 +1,4 @@
+<div>
+	This is the path to use.
+	<i>Do not begin with a leading "/".</i>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help.html
@@ -1,0 +1,6 @@
+<div>
+	<p>
+		Upload a file/folder from the workspace to an S3 bucket.
+		If the file parameter denotes a directory, then the complete directory (including all subfolders) will be uploaded.
+	</p>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/config.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%Region}" field="region">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Credentials}" field="credentials">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Profile}" field="profile">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Role}" field="role">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Role Account}" field="roleAccount">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%External ID}" field="externalId">
+		<f:textbox />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-credentials.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-credentials.html
@@ -1,0 +1,4 @@
+<div>
+	Use standard Jenkins UsernamePassword credentials.
+	Note: the username should be your Access Key ID, and the password should be the Secret Access Key.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-externalId.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-externalId.html
@@ -1,0 +1,3 @@
+<div>
+	(optional) The external ID.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-profile.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-profile.html
@@ -1,0 +1,3 @@
+<div>
+	Use this profile information from <tt>~/.aws/config</tt>.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-region.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-region.html
@@ -1,0 +1,3 @@
+<div>
+	The AWS region.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-role.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-role.html
@@ -1,0 +1,3 @@
+<div>
+	Assume role information (<i>Role Account</i> is optional; it uses current account as default, <i>External ID</i> is optional).
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-roleAccount.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-roleAccount.html
@@ -1,0 +1,4 @@
+<div>
+	(optional) The account to use.
+	This uses current account by default.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help.html
@@ -1,0 +1,7 @@
+<div>
+	<p>
+		The <tt>withAWS</tt> step provides authorization for the nested steps.
+		You can provide region and profile information or let Jenkins assume a role in another or the same AWS account.
+		You can mix all parameters in one <tt>withAWS</tt> block.
+	</p>
+</div>


### PR DESCRIPTION
I added support for the Pipeline Syntax snippet generator.  This basically means that there are some Jelly and HTML files in the resources folder that help Jenkins figure out what the possible parameters are help the users figure out which ones they need to use and how.

I only supported `withAWS`, `s3Download`, and `s3Upload`, since those are the only ones that I have experience with.  Doing the others should be easy, but I'll leave that for another time.

In the `withAWS` code, I noticed that none of the strings had any default values.  I defaulted them all to the empty string, which is kind of what the code seems to be assuming that they are, anyway.  This lets the snippet generator only fill out parameters that have been given a value, which makes sense given the way that the README.md documentation is written.

Finally, I noticed that if the S3 upload path begins with a "/", then a "//" will be written into the final path string, and S3 will actually create a zero-length folder name, which is definitely not what people want.  So, I updated README.md and the help text for the `path` parameter accordingly.