### PR TITLE
Replaces slash in RoleSessionName

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -242,7 +242,7 @@ public class WithAWSStep extends AbstractStepImpl {
 		}
 		
 		private String createRoleSessionName() {
-			String job_name = this.envVars.get("JOB_NAME").replace(" ", "");
+			String job_name = this.envVars.get("JOB_NAME").replace(" ", "").replace("/", "-");
 			return "Jenkins-" + job_name + "-" + this.envVars.get("BUILD_NUMBER");
 		}
 		


### PR DESCRIPTION
With organization folders, the separator is slash.