### PR TITLE
Add new step: s3Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This plugins adds Jenkins pipeline steps to interact with the AWS API.
 
 ## withAWS
 
-the `withAWS` step provides authorization for the nested steps. 
-You can provide region and profile information or let Jenkins 
-assume a role in another or the same AWS account. 
+the `withAWS` step provides authorization for the nested steps.
+You can provide region and profile information or let Jenkins
+assume a role in another or the same AWS account.
 You can mix all parameters in one `withAWS` block.
 
 Set region information:
@@ -77,7 +77,7 @@ s3Upload(file:'someFolder', bucket:'my-bucket', path:'path/to/targetFolder/')
 
 ## s3Download
 
-Download a file/folder from S3 to the local workspace. 
+Download a file/folder from S3 to the local workspace.
 Set optional parameter `force` to `true` to overwrite existing file in workspace.
 If the `path` ends with a `/` the complete virtual directory will be downloaded.
 
@@ -89,12 +89,11 @@ s3Download(file:'targetFolder/', bucket:'my-bucket', path:'path/to/sourceFolder/
 ## s3Delete
 
 Delete a file/folder from S3.
-Set the optional parameter `recursive` to `true` to treat `path` as a directory structure (with directories separated by "/") to remove it and all of its children.
-Using the `recursive` option on a file (as opposed to a folder) is perfectly valid, but it will also attempt to remove any "children" of that path if they exist.
+If the path ends in a "/", then the path will be interpreted to be a folder, and all of its contents will be removed.
 
 ```
 s3Delete(bucket:'my-bucket', path:'path/to/source/file.txt')
-s3Delete(bucket:'my-bucket', path:'path/to/sourceFolder', recursive:true)
+s3Delete(bucket:'my-bucket', path:'path/to/sourceFolder/')
 ```
 
 ## cfnValidate
@@ -108,14 +107,14 @@ cfnValidate(file:'template.yaml')
 ## cfnUpdate
 
 Create or update the given CloudFormation stack using the given template from the workspace.
-You can specify an optional list of parameters. 
+You can specify an optional list of parameters.
 You can also specify a list of `keepParams` of parameters which will use the previous value on stack updates.
 
 Using `timeoutInMinutes` you can specify the amount of time that can pass before the stack status becomes CREATE_FAILED and the stack gets rolled back.
 Due to limitations in the AWS API, this only applies to stack creation.
 
-If you have many parameters you can specify a `paramsFile` containing the parameters. The format is either a standard 
-JSON file like with the cli or a YAML file for the [cfn-params](https://www.npmjs.com/package/cfn-params) command line utility. 
+If you have many parameters you can specify a `paramsFile` containing the parameters. The format is either a standard
+JSON file like with the cli or a YAML file for the [cfn-params](https://www.npmjs.com/package/cfn-params) command line utility.
 
 Additionally you can specify a list of tags that are set on the stack and all resources created by CloudFormation.
 The step returns the outputs of the stack as a map.
@@ -184,7 +183,7 @@ deployAPI(api:'myApiId', stage:'Prod', description:"Build: ${env.BUILD_ID}", var
 
 ## awaitDeploymentCompletion
 
-Awaits for a CodeDeploy deployment to complete. 
+Awaits for a CodeDeploy deployment to complete.
 
 The step runs within the `withAWS` block and requires only one parameter:
 
@@ -242,11 +241,11 @@ timeout(time: 15, unit: 'MINUTES'){
 ## 1.4
 * add empty checks for mandatory strings
 * use latest AWS SDK
-* add support for CloudFormation stack tags 
+* add support for CloudFormation stack tags
 
 ## 1.3
 * add support for publishing messages to SNS
-* fail step on errors during CloudFormation actions 
+* fail step on errors during CloudFormation actions
 
 ## 1.2
 * add proxy support using standard environment variables
@@ -255,7 +254,7 @@ timeout(time: 15, unit: 'MINUTES'){
 ## 1.1
 * fixing invalidation of CloudFront distributions
 * add output of stack creation, updates and deletes
-* Only fetch AWS environment once 
+* Only fetch AWS environment once
 * make long-running steps async
 
 ## 1.0

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ s3Download(file:'file.txt', bucket:'my-bucket', path:'path/to/source/file.txt', 
 s3Download(file:'targetFolder/', bucket:'my-bucket', path:'path/to/sourceFolder/', force:true)
 ```
 
+## s3Delete
+
+Delete a file/folder from S3.
+Set the optional parameter `recursive` to `true` to treat `path` as a directory structure (with directories separated by "/") to remove it and all of its children.
+Using the `recursive` option on a file (as opposed to a folder) is perfectly valid, but it will also attempt to remove any "children" of that path if they exist.
+
+```
+s3Delete(bucket:'my-bucket', path:'path/to/source/file.txt')
+s3Delete(bucket:'my-bucket', path:'path/to/sourceFolder', recursive:true)
+```
+
 ## cfnValidate
 
 Validates the given CloudFormation template.

--- a/src/main/java/de/taimos/pipeline/aws/S3DeleteStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3DeleteStep.java
@@ -1,0 +1,225 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2016 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.remoting.RoleChecker;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import com.amazonaws.event.ProgressEvent;
+import com.amazonaws.event.ProgressEventType;
+import com.amazonaws.event.ProgressListener;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.base.Preconditions;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+
+/**
+ * The S3DeleteStep deletes an object from S3.
+ * If the "recursive" option is set, then this interprets the object as a folder
+ * and removes all content, as well.
+ */
+public class S3DeleteStep extends AbstractStepImpl {
+	/**
+	 * This is the bucket name.
+	 */
+	private final String bucket;
+	/**
+	 * This is the path to the object.
+	 */
+	private final String path;
+	/**
+	 * This is whether or not we'll be performing a recursive delete action.
+	 */
+	private boolean recursive = false;
+
+	@DataBoundConstructor
+	public S3DeleteStep(String bucket, String path) {
+		this.bucket = bucket;
+		this.path = path;
+	}
+
+	public String getBucket() {
+		return this.bucket;
+	}
+
+	public String getPath() {
+		return this.path;
+	}
+
+	public boolean isRecursive() {
+		return this.recursive;
+	}
+
+	@DataBoundSetter
+	public void setRecursive(boolean recursive) {
+		this.recursive = recursive;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+		public DescriptorImpl() {
+			super(Execution.class);
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "s3Delete";
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Delete file from S3";
+		}
+	}
+
+	public static class Execution extends AbstractStepExecutionImpl {
+
+		@Inject
+		private transient S3DeleteStep step;
+		@StepContextParameter
+		private transient EnvVars envVars;
+		@StepContextParameter
+		private transient FilePath workspace;
+		@StepContextParameter
+		private transient TaskListener listener;
+
+		@Override
+		public boolean start() throws Exception {
+			final String bucket = this.step.getBucket();
+			final String path = this.step.getPath();
+			final boolean recursive = this.step.isRecursive();
+
+			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
+
+			new Thread("s3Delete") {
+				@Override
+				public void run() {
+					try {
+						Execution.this.listener.getLogger().format("Deleting s3://%s/%s %s%n", bucket, path, recursive ? "recursively" : "" );
+
+						AmazonS3Client s3Client = AWSClientFactory.create(AmazonS3Client.class, Execution.this.envVars);
+						if( ! recursive ) {
+							// See if the thing that we were given is a file.
+							if( s3Client.doesObjectExist( bucket, path ) ) {
+								Execution.this.listener.getLogger().format("Deleting object at s3://%s/%s%n", bucket, path );
+								s3Client.deleteObject( bucket, path );
+							}
+						} else {
+							// This is the list of keys to delete from the bucket.
+							List<String> objectsToDelete = new ArrayList<>();
+
+							// See if the thing that we were given is a file.
+							if( s3Client.doesObjectExist( bucket, path ) ) {
+								objectsToDelete.add( path );
+							}
+
+							// This is the list of folders that we need to investigate.
+							// We're going to start with the path that we've been given,
+							// and then we'll grow it from there.
+							List<String> folders = new ArrayList<>();
+							folders.add( path );
+
+							// Go through all of the folders that we need to investigate,
+							// popping the first item off and working on it.  When they're
+							// all gone, we'll be done.
+							while( folders.size() > 0 ) {
+								// This is the folder to investigate.
+								String folder = folders.remove( 0 );
+
+								// Create the request to list the objects within it.
+								ListObjectsRequest request = new ListObjectsRequest();
+								request.setBucketName( bucket );
+								request.setPrefix( folder );
+								request.setDelimiter( "/" );
+								if( ! folder.endsWith("/") ) {
+									request.setPrefix( folder + "/" );
+								}
+
+								// Get the list of objects within the folder.  Because AWS
+								// might paginate this, we're going to continue dealing with
+								// the "objectListing" object until it claims that it's done.
+								ObjectListing objectListing = s3Client.listObjects(request);
+								while( true ) {
+									// Add any real objects to the list of objects to delete.
+									for( S3ObjectSummary entry : objectListing.getObjectSummaries() ) {
+										objectsToDelete.add( entry.getKey() );
+									}
+									// Add any folders to the list of folders that we need to investigate.
+									folders.addAll( objectListing.getCommonPrefixes() );
+
+									// If this listing is complete, then we can stop.
+									if( ! objectListing.isTruncated() ) {
+										break;
+									}
+									// Otherwise, we need to get the next batch and repeat.
+									objectListing = s3Client.listNextBatchOfObjects(objectListing);
+								}
+							}
+
+							// Go through all of the objects that we want to delete and actually delete them.
+							for( String objectToDelete : objectsToDelete ) {
+								Execution.this.listener.getLogger().format("Deleting object at s3://%s/%s%n", bucket, objectToDelete );
+								s3Client.deleteObject( bucket, objectToDelete );
+							}
+						}
+
+						Execution.this.listener.getLogger().println("Delete complete");
+						Execution.this.getContext().onSuccess(null);
+					} catch (Exception e) {
+						Execution.this.getContext().onFailure(e);
+					}
+				}
+			}.start();
+			return false;
+		}
+
+		@Override
+		public void stop(@Nonnull Throwable cause) throws Exception {
+			//
+		}
+
+		private static final long serialVersionUID = 1L;
+
+	}
+}

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/config.jelly
@@ -6,7 +6,4 @@
 	<f:entry title="${%Path}" field="path">
 		<f:textbox />
 	</f:entry>
-	<f:entry title="${%Recursive}" field="recursive">
-		<f:checkbox default="false" />
-	</f:entry>
 </j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%Bucket}" field="bucket">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Path}" field="path">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Recursive}" field="recursive">
+		<f:checkbox default="false" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-bucket.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-bucket.html
@@ -1,0 +1,3 @@
+<div>
+	This is the bucket to use.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-path.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-path.html
@@ -1,0 +1,4 @@
+<div>
+	This is the path inside the bucket to use.
+	<i>Do not begin with a leading "/".</i>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-path.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-path.html
@@ -1,4 +1,9 @@
 <div>
-	This is the path inside the bucket to use.
-	<i>Do not begin with a leading "/".</i>
+	<p>
+		This is the path inside the bucket to delete.
+		If this ends in a "/", then the path will be interpreted to be a folder, and all of its contents will be removed.
+	</p>
+	<p>
+		<i>Do not begin with a leading "/".</i>
+	</p>
 </div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-recursive.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-recursive.html
@@ -1,0 +1,3 @@
+<div>
+	Set this to true to delete the S3 files recursively.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-recursive.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help-recursive.html
@@ -1,3 +1,0 @@
-<div>
-	Set this to true to delete the S3 files recursively.
-</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help.html
@@ -1,6 +1,6 @@
 <div>
 	<p>
 		Delete a file/folder from S3.
-		Set optional parameter <tt>recursive</tt> to true to recursively delete all contents of <tt>path</tt>.
+		If the path ends in a "/", then the path will be interpreted to be a folder, and all of its contents will be removed.
 	</p>
 </div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DeleteStep/help.html
@@ -1,0 +1,6 @@
+<div>
+	<p>
+		Delete a file/folder from S3.
+		Set optional parameter <tt>recursive</tt> to true to recursively delete all contents of <tt>path</tt>.
+	</p>
+</div>

--- a/src/test/java/de/taimos/pipeline/aws/S3DeleteStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3DeleteStepTest.java
@@ -1,0 +1,43 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3DeleteStepTest {
+
+	@Test
+	public void recursiveDefaultsToFalse() throws Exception {
+		S3DeleteStep step = new S3DeleteStep( "my-bucket", "my-path" );
+		Assert.assertFalse( step.isRecursive() );
+	}
+
+	@Test
+	public void gettersWorkAsExpected() throws Exception {
+		S3DeleteStep step = new S3DeleteStep( "my-bucket", "my-path" );
+		Assert.assertEquals( "my-bucket", step.getBucket() );
+		Assert.assertEquals( "my-path", step.getPath() );
+	}
+}

--- a/src/test/java/de/taimos/pipeline/aws/S3DeleteStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3DeleteStepTest.java
@@ -27,13 +27,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class S3DeleteStepTest {
-
-	@Test
-	public void recursiveDefaultsToFalse() throws Exception {
-		S3DeleteStep step = new S3DeleteStep( "my-bucket", "my-path" );
-		Assert.assertFalse( step.isRecursive() );
-	}
-
 	@Test
 	public void gettersWorkAsExpected() throws Exception {
 		S3DeleteStep step = new S3DeleteStep( "my-bucket", "my-path" );

--- a/src/test/java/de/taimos/pipeline/aws/S3DownloadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3DownloadStepTest.java
@@ -1,0 +1,48 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3DownloadStepTest {
+	@Test
+	public void gettersWorkAsExpected() throws Exception {
+		S3DownloadStep step = new S3DownloadStep( "my-file", "my-bucket" );
+		Assert.assertEquals( "my-file", step.getFile() );
+		Assert.assertEquals( "my-bucket", step.getBucket() );
+	}
+
+	@Test
+	public void defaultPathIsEmpty() throws Exception {
+		S3DownloadStep step = new S3DownloadStep( "my-file", "my-bucket" );
+		Assert.assertEquals( "", step.getPath() );
+	}
+
+	@Test
+	public void defaultForceIsFalse() throws Exception {
+		S3DownloadStep step = new S3DownloadStep( "my-file", "my-bucket" );
+		Assert.assertFalse( step.isForce() );
+	}
+}

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -1,0 +1,42 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3UploadStepTest {
+	@Test
+	public void gettersWorkAsExpected() throws Exception {
+		S3UploadStep step = new S3UploadStep( "my-file", "my-bucket" );
+		Assert.assertEquals( "my-file", step.getFile() );
+		Assert.assertEquals( "my-bucket", step.getBucket() );
+	}
+
+	@Test
+	public void defaultPathIsEmpty() throws Exception {
+		S3UploadStep step = new S3UploadStep( "my-file", "my-bucket" );
+		Assert.assertEquals( "", step.getPath() );
+	}
+}


### PR DESCRIPTION
This deletes the object stored in the bucket at the given path. If the path ends with "/", then this interprets the path as a folder and deletes all of the objects stored "within" that folder.

Of course, S3 does not actually contain folders; it is a flat structure. However, S3 has full support for using it to contain pseudo-hierarchies using a delimiter and some "prefix" logic.  Since the "s3Upload" and "s3Download" steps already support this with the "/" delimiter, "s3Delete" does so as well.

In terms of logging, "s3Delete" will log analogously to "s3Upload" and "s3Download"; that is, it will log the beginning and end of the operation.  In addition, it will log when it *actually* deletes an object.