### PR TITLE
Add step: s3FindFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The `glob` parameter tells `s3FindFiles` what to look for.  This can be a file n
 
 If you do not specify `path`, then it will default to the root of the bucket.
 The path is assumed to be a folder; you do not need to end it with a "/", but it is okay if you do.
+The `path` property of the results will be _relative_ to this value.
+
+This works by enumerating _every_ file/folder in the S3 bucket under `path` and then performing glob matching.
+When possible, you should use `path` to limit the search space for efficiency purposes.
 
 If you do not specify `glob`, then it will default to "\*".
 
@@ -113,9 +117,9 @@ To only return files, set the `onlyFiles` parameter to `true`.
 ```
 files = s3FindFiles(bucket:'my-bucket')
 files = s3FindFiles(bucket:'my-bucket', glob:'path/to/targetFolder/file.ext')
-files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'file.ext')
-files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'*.ext')
-files = s3FindFiles(bucket:'my-bucket', path:'path', glob:'**/file.ext')
+files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder/', glob:'file.ext')
+files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder/', glob:'*.ext')
+files = s3FindFiles(bucket:'my-bucket', path:'path/', glob:'**/file.ext')
 ```
 
 `s3FindFiles` returns an array of `FileWrapper` objects exactly identical to those returned by `findFiles`.
@@ -123,12 +127,12 @@ files = s3FindFiles(bucket:'my-bucket', path:'path', glob:'**/file.ext')
 Each `FileWrapper` object has the following properties:
 
 * `name`: the filename portion of the path (for "path/to/my/file.ext", this would be "file.ext")
-* `path`: the full path of the file (for "path/to/my/file.ext", this would be "path/to/my/file.ext")
+* `path`: the full path of the file, _relative_ to the `path` specified (for `path`="path/to/", this property of the file "path/to/my/file.ext" would be "my/file.ext")
 * `directory`: true if this is a directory; false otherwise
 * `length`: the length of the file (this is always "0" for directories)
 * `lastModified`: the last modification timestamp, in milliseconds since the Unix epoch (this is always "0" for directories)
 
-When used in a string context, a `FileWrapper` object returns the value of its `path`.
+When used in a string context, a `FileWrapper` object returns the value of its `path` property.
 
 ## cfnValidate
 
@@ -253,6 +257,7 @@ def accounts = listAWSAccounts()
 # Changelog
 
 ## 1.13 (master)
+* Add `s3FindFiles` step
 
 ## 1.12
 * Make polling interval for CFN events configurable #JENKINS-45348

--- a/README.md
+++ b/README.md
@@ -96,6 +96,40 @@ s3Delete(bucket:'my-bucket', path:'path/to/source/file.txt')
 s3Delete(bucket:'my-bucket', path:'path/to/sourceFolder/')
 ```
 
+## s3FindFiles
+
+This provides a way to query the files/folders in the S3 bucket, analogous to the `findFiles` step provided by "pipeline-utility-steps-plugin".
+If specified, the `path` limits the scope of the operation to that folder only.
+The `glob` parameter tells `s3FindFiles` what to look for.  This can be a file name, a full path to a file, or a standard glob ("\*", "\*.ext", "path/\*\*/file.ext", etc.).
+
+If you do not specify `path`, then it will default to the root of the bucket.
+The path is assumed to be a folder; you do not need to end it with a "/", but it is okay if you do.
+
+If you do not specify `glob`, then it will default to "\*".
+
+By default, this will return both files and folders.
+To only return files, set the `onlyFiles` parameter to `true`.
+
+```
+files = s3FindFiles(bucket:'my-bucket')
+files = s3FindFiles(bucket:'my-bucket', glob:'path/to/targetFolder/file.ext')
+files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'file.ext')
+files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'file.ext')
+files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'*.ext')
+```
+
+`s3FindFiles` returns an array of `FileWrapper` objects exactly identical to those returned by `findFiles`.
+
+Each `FileWrapper` object has the following properties:
+
+* `name`: the filename portion of the path (for "path/to/my/file.ext", this would be "file.ext")
+* `path`: the full path of the file (for "path/to/my/file.ext", this would be "path/to/my/file.ext")
+* `directory`: true if this is a directory; false otherwise
+* `length`: the length of the file (this is always "0" for directories)
+* `lastModified`: the last modification timestamp, in milliseconds since the Unix epoch (this is always "0" for directories)
+
+When used in a string context, a `FileWrapper` object returns the value of its `path`.
+
 ## cfnValidate
 
 Validates the given CloudFormation template.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ To only return files, set the `onlyFiles` parameter to `true`.
 files = s3FindFiles(bucket:'my-bucket')
 files = s3FindFiles(bucket:'my-bucket', glob:'path/to/targetFolder/file.ext')
 files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'file.ext')
-files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'file.ext')
 files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'*.ext')
+files = s3FindFiles(bucket:'my-bucket', path:'path', glob:'**/file.ext')
 ```
 
 `s3FindFiles` returns an array of `FileWrapper` objects exactly identical to those returned by `findFiles`.

--- a/src/main/java/de/taimos/pipeline/aws/FileWrapper.java
+++ b/src/main/java/de/taimos/pipeline/aws/FileWrapper.java
@@ -1,0 +1,124 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 CloudBees Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/*
+ * Note: this is a direct copy of the FileWrapper from:
+ * https://github.com/jenkinsci/pipeline-utility-steps-plugin/raw/master/src/main/java/org/jenkinsci/plugins/pipeline/utility/steps/fs/FileWrapper.java
+ * from the "pipeline-utility-steps-plugin".
+ */
+
+package de.taimos.pipeline.aws;
+
+import hudson.FilePath;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Contains serializable information about a file name.
+ *
+ * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
+ */
+public class FileWrapper implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Nonnull
+    private final String name;
+    @Nonnull
+    private final String path;
+    private final boolean directory;
+    private final long length;
+    private final long lastModified;
+
+    public FileWrapper(@Nonnull String name, @Nonnull String path, boolean directory, long length, long lastModified) {
+        this.name = name;
+        this.directory = directory;
+        this.length = length;
+        this.lastModified = lastModified;
+        if (directory && !path.endsWith("/")) {
+            this.path = path + "/";
+        } else {
+            this.path = path;
+        }
+    }
+
+    protected FileWrapper(@Nonnull FilePath base, @Nonnull FilePath file) throws IOException, InterruptedException {
+        this(file.getName(),
+                file.getRemote().substring(base.getRemote().length() + 1),
+                file.isDirectory(),
+                file.length(),
+                file.lastModified());
+    }
+
+    protected FileWrapper(@Nonnull FilePath file) throws IOException, InterruptedException {
+        this(file.getName(), file.getRemote(), file.isDirectory(), file.length(), file.lastModified());
+    }
+
+    @Whitelisted @Nonnull
+    public String getName() {
+        return name;
+    }
+
+    @Whitelisted @Nonnull
+    public String getPath() {
+        return path;
+    }
+
+    @Whitelisted
+    public boolean isDirectory() {
+        return directory;
+    }
+
+    @Whitelisted
+    public long getLength() {
+        return length;
+    }
+
+    @Whitelisted
+    public long getLastModified() {
+        return lastModified;
+    }
+
+    @Override @Whitelisted @Nonnull
+    public String toString() {
+        return getPath();
+    }
+
+    @Override @Whitelisted
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FileWrapper)) return false;
+
+        FileWrapper that = (FileWrapper)o;
+
+        return getPath().equals(that.getPath());
+
+    }
+
+    @Override @Whitelisted
+    public int hashCode() {
+        return getPath().hashCode();
+    }
+}

--- a/src/main/java/de/taimos/pipeline/aws/S3FindFilesStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3FindFilesStep.java
@@ -177,7 +177,6 @@ public class S3FindFilesStep extends AbstractStepImpl {
 				// Note that a glob of "**" will match everything (both files and folders) under
 				// the path.
 				final String matcherString = "glob:" + ( path.length() == 0 ? "" : path + ( path.endsWith("/") ? "" : "/" ) ) + ( glob.length() == 0 ? "*" : glob );
-				Execution.this.listener.getLogger().format("Matcher string: %s%n", matcherString ); // TODO REMOVE
 				PathMatcher matcher = FileSystems.getDefault().getPathMatcher( matcherString );
 
 				// This is how may components there are in the root path.  We'll use this information

--- a/src/main/java/de/taimos/pipeline/aws/S3FindFilesStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3FindFilesStep.java
@@ -1,0 +1,250 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2016 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.base.Preconditions;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+
+/**
+ * The S3FindFilesStep returns a list of files from S3 that match a pattern.
+ * This is intended to be analogous to the "findFiles" step provided by the
+ * "pipeline-utility-steps-plugin".
+ *
+ * This thus accepts a bucket, a path, and a glob pattern.
+ *
+ * The path, if specified, sets the root of the search.  If left unspecified, then
+ * this defaults to the root of the bucket.
+ *
+ * The glob, if specified, sets the glob that should be matched.  If left unspecified,
+ * then this defaults to "*", which will match everything within `path`, but only
+ * one level deep.  To match absolutely everything, use "**".
+ */
+public class S3FindFilesStep extends AbstractStepImpl {
+	/**
+	 * This is the bucket name.
+	 */
+	private final String bucket;
+	/**
+	 * This is the path to limit the search to.
+	 * This defaults to the empty string, which is the root of the bucket.
+	 */
+	private String path = "";
+	/**
+	 * This is the glob.
+	 * This defaults to the empty string, which lists the files directly under the path.
+	 */
+	private String glob = "";
+	/**
+	 * This is whether or not we are only going to return files.
+	 * By default, both files and folders are returned.
+	 */
+	private boolean onlyFiles = false;
+
+	@DataBoundConstructor
+	public S3FindFilesStep(String bucket) {
+		this.bucket = bucket;
+	}
+
+	public String getBucket() {
+		return this.bucket;
+	}
+
+	@DataBoundSetter
+	public void setPath( String path ) {
+		this.path = path;
+	}
+
+	public String getPath() {
+		return this.path;
+	}
+
+	@DataBoundSetter
+	public void setGlob( String glob ) {
+		this.glob = glob;
+	}
+
+	public String getGlob() {
+		return this.glob;
+	}
+
+	@DataBoundSetter
+	public void setOnlyFiles( boolean onlyFiles ) {
+		this.onlyFiles = onlyFiles;
+	}
+
+	public boolean isOnlyFiles() {
+		return this.onlyFiles;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+		public DescriptorImpl() {
+			super(Execution.class);
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "s3FindFiles";
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Find files in S3";
+		}
+	}
+
+	public static class Execution extends AbstractSynchronousNonBlockingStepExecution<String[]> {
+		private static final long serialVersionUID = 1L;
+
+		@Inject
+		private transient S3FindFilesStep step;
+		@StepContextParameter
+		private transient EnvVars envVars;
+		@StepContextParameter
+		private transient FilePath workspace;
+		@StepContextParameter
+		private transient TaskListener listener;
+
+		@Override
+		public String[] run() throws Exception {
+			final String bucket = this.step.getBucket();
+			final String path = this.step.getPath();
+			final String glob = this.step.getGlob();
+			final boolean onlyFiles = this.step.isOnlyFiles();
+
+			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
+
+			try {
+				Execution.this.listener.getLogger().format("Searching s3://%s/%s for glob:'%s' %s%n", bucket, path, glob, onlyFiles ? "(only files)" : "" );
+
+				AmazonS3Client s3Client = AWSClientFactory.create(AmazonS3Client.class, Execution.this.envVars);
+
+				// Construct a PatternMatcher to match the files.
+				// Essentially, we're going to match against "${path}/${glob}".  Obviously,
+				// if there's no path, then we're going to leave that part out.  If no glob
+				// was given, then we're going to default to "*", which will match everything
+				// at the level of the path (but no deeper).
+				//
+				// Note that a glob of "**" will match everything (both files and folders) under
+				// the path.
+				final String matcherString = "glob:" + ( path.length() == 0 ? "" : path + ( path.endsWith("/") ? "" : "/" ) ) + ( glob.length() == 0 ? "*" : glob );
+				Execution.this.listener.getLogger().format("Matcher string: %s%n", matcherString ); // TODO REMOVE
+				PathMatcher matcher = FileSystems.getDefault().getPathMatcher( matcherString );
+
+				// This is the list of keys that match from the bucket.
+				List<String> matchingObjects = new ArrayList<>();
+
+				// This is the list of folders that we need to investigate.
+				// We're going to start with the path that we've been given,
+				// and then we'll grow it from there.
+				List<String> folders = new ArrayList<>();
+				folders.add( path );
+
+				// Go through all of the folders that we need to investigate,
+				// popping the first item off and working on it.  When they're
+				// all gone, we'll be done.
+				while( folders.size() > 0 ) {
+					// This is the folder to investigate.
+					String folder = folders.remove( 0 );
+
+					// Create the request to list the objects within it.
+					ListObjectsRequest request = new ListObjectsRequest();
+					request.setBucketName( bucket );
+					request.setPrefix( folder );
+					request.setDelimiter( "/" );
+					if( folder.length() > 0 && ! folder.endsWith("/") ) {
+						request.setPrefix( folder + "/" );
+					}
+
+					// Get the list of objects within the folder.  Because AWS
+					// might paginate this, we're going to continue dealing with
+					// the "objectListing" object until it claims that it's done.
+					ObjectListing objectListing = s3Client.listObjects(request);
+					while( true ) {
+						// Add any real objects to the list of objects to delete.
+						for( S3ObjectSummary entry : objectListing.getObjectSummaries() ) {
+							if( matcher.matches( Paths.get(entry.getKey()) ) ) {
+								matchingObjects.add( entry.getKey() );
+							}
+						}
+						// Add any folders to the list of folders that we need to investigate.
+						folders.addAll( objectListing.getCommonPrefixes() );
+						// In addition, if we are allowed to add folders to the list, then
+						// go through the folders and add any matching ones.
+						if( ! onlyFiles ) {
+							for( String prefix : objectListing.getCommonPrefixes() ) {
+								if( matcher.matches( Paths.get(prefix) ) ) {
+									matchingObjects.add( prefix );
+								}
+							}
+						}
+
+						// If this listing is complete, then we can stop.
+						if( ! objectListing.isTruncated() ) {
+							break;
+						}
+						// Otherwise, we need to get the next batch and repeat.
+						objectListing = s3Client.listNextBatchOfObjects(objectListing);
+					}
+				}
+
+				String[] stepResult = new String[ matchingObjects.size() ];
+				stepResult = matchingObjects.toArray( stepResult );
+
+				Execution.this.listener.getLogger().println("Search complete");
+				return stepResult;
+			} catch (Exception e) {
+				Execution.this.getContext().onFailure(e);
+				return null;
+			}
+		}
+	}
+}

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/config.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%Bucket}" field="bucket">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Path}" field="path">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%OnlyFiles}" field="onlyFiles">
+		<f:checkbox default="false" />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/config.jelly
@@ -6,7 +6,7 @@
 	<f:entry title="${%Path}" field="path">
 		<f:textbox />
 	</f:entry>
-	<f:entry title="${%OnlyFiles}" field="onlyFiles">
+	<f:entry title="${%Only Files}" field="onlyFiles">
 		<f:checkbox default="false" />
 	</f:entry>
 </j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-bucket.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-bucket.html
@@ -1,0 +1,3 @@
+<div>
+	This is the bucket to use.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-glob.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-glob.html
@@ -1,0 +1,12 @@
+<div>
+	<p>
+		This is the glob to use to match files/folders.
+		You may use a full file name/path (for example "path/to/file.ext"), but you may also use a glob (for example, "path/t*/file.*").
+	</p>
+	<p>
+		If left blank, this will perform the equivalent function of "*".
+	</p>
+	<p>
+		To list absolutely everything, use "**".
+	</p>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-onlyFiles.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-onlyFiles.html
@@ -1,0 +1,4 @@
+<div>
+	Set this to <tt>true</tt> to only return actual files.
+	Otherwise, by default, this will return both files and folders.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-path.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help-path.html
@@ -1,0 +1,4 @@
+<div>
+	This is the path inside the bucket to use as the root of the search.
+	<i>Do not begin with a leading "/".</i>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
@@ -2,13 +2,26 @@
 	<p>
 		Return a list of all of the files/folders in the bucket.
 		If <tt>path</tt> is given, then it will be used as the root of the search.
+		Results are returned <i>relative</i> to <tt>path</tt>; if <tt>path</tt> is not given, then the results will contain the full S3 path.
 	</p>
 	<p>
-		The following all ultimately return one item: "path/to/my/file.ext"; however, limiting the scope using <tt>path</tt> is the most efficient:
+		The following all ultimately return one item referring to "path/to/my/file.ext"; however, by limiting the scope via <tt>path</tt>, the results are different.
 		<ul>
-			<li><tt>s3FindFiles bucket: "my-bucket", glob: "path/to/my/file.ext"</tt></li>
-			<li><tt>s3FindFiles bucket: "my-bucket", path: "path/to", glob: "my/file.ext"</tt></li>
-			<li><tt>s3FindFiles bucket: "my-bucket", path: "path/to/my", glob: "file.ext"</tt></li>
+			<li>
+				<tt>files = s3FindFiles bucket: "my-bucket", glob: "path/to/my/file.ext"</tt><br>
+				<tt>// files[0].name = "file.ext"</tt><br>
+				<tt>// files[0].path = "path/to/my/file.ext"</tt>
+			</li>
+			<li>
+				<tt>files = s3FindFiles bucket: "my-bucket", path: "path/to/", glob: "my/file.ext"</tt><br>
+				<tt>// files[0].name = "file.ext"</tt><br>
+				<tt>// files[0].path = "my/file.ext"</tt>
+			</li>
+			<li>
+				<tt>files = s3FindFiles bucket: "my-bucket", path: "path/to/my/", glob: "file.ext"</tt><br>
+				<tt>// files[0].name = "file.ext"</tt><br>
+				<tt>// files[0].path = "file.ext"</tt>
+			</li>
 		</ul>
 	</p>
 	<p>
@@ -22,7 +35,7 @@
 		This will return an array of <tt>FileWrapper</tt> instances with the following properties:
 		<ul>
 			<li><tt>name</tt>: the filename portion of the path (for "path/to/my/file.ext", this would be "file.ext")</li>
-			<li><tt>path</tt>: the full path of the file (for "path/to/my/file.ext", this would be "path/to/my/file.ext")</li>
+			<li><tt>path</tt>: the full path of the file, <i>relative</i> to the <tt>path</tt> specified (for <tt>path</tt>="path/to/", this property of the file "path/to/my/file.ext" would be "my/file.ext")</li>
 			<li><tt>directory</tt>: true if this is a directory; false otherwise</li>
 			<li><tt>length</tt>: the length of the file (this is always "0" for directories)</li>
 			<li><tt>lastModified</tt>: the last modification timestamp, in milliseconds since the Unix epoch (this is always "0" for directories)</li>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
@@ -1,0 +1,20 @@
+<div>
+	<p>
+		List all of the files/folders in the bucket.
+		If <tt>path</tt> is given, then it will be used as the root of the search.
+	</p>
+	<p>
+		The following are equivalent:
+		<ul>
+			<li><tt>s3FindFiles bucket: "my-bucket", glob: "path/to/my/file.ext"</tt></li>
+			<li><tt>s3FindFiles bucket: "my-bucket", path: "path/to", glob: "my/file.ext"</tt></li>
+			<li><tt>s3FindFiles bucket: "my-bucket", path: "path/to/", glob: "my/file.ext"</tt></li>
+		</ul>
+	</p>
+	<p>
+		List every file:
+		<ul>
+			<li><tt>s3FindFiles bucket: "my-bucket", glob: "**", onlyFiles: true</tt></li>
+		</ul>
+	</p>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
@@ -1,6 +1,6 @@
 <div>
 	<p>
-		List all of the files/folders in the bucket.
+		Return a list of all of the files/folders in the bucket.
 		If <tt>path</tt> is given, then it will be used as the root of the search.
 	</p>
 	<p>
@@ -12,9 +12,21 @@
 		</ul>
 	</p>
 	<p>
-		List every file:
+		List every file in the bucket:
 		<ul>
 			<li><tt>s3FindFiles bucket: "my-bucket", glob: "**", onlyFiles: true</tt></li>
 		</ul>
+	</p>
+	<p>
+		The return format is identical to that of the <tt>findFiles</tt> step.
+		This will return an array of <tt>FileWrapper</tt> instances with the following properties:
+		<ul>
+			<li><tt>name</tt>: the filename portion of the path (for "path/to/my/file.ext", this would be "file.ext")</li>
+			<li><tt>path</tt>: the full path of the file (for "path/to/my/file.ext", this would be "path/to/my/file.ext")</li>
+			<li><tt>directory</tt>: true if this is a directory; false otherwise</li>
+			<li><tt>length</tt>: the length of the file (this is always "0" for directories)</li>
+			<li><tt>lastModified</tt>: the last modification timestamp, in milliseconds since the Unix epoch (this is always "0" for directories)</li>
+		</ul>
+		When used in a string context, a <tt>FileWrapper</tt> object returns the value of its <tt>path<tt>.
 	</p>
 </div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3FindFilesStep/help.html
@@ -4,11 +4,11 @@
 		If <tt>path</tt> is given, then it will be used as the root of the search.
 	</p>
 	<p>
-		The following are equivalent:
+		The following all ultimately return one item: "path/to/my/file.ext"; however, limiting the scope using <tt>path</tt> is the most efficient:
 		<ul>
 			<li><tt>s3FindFiles bucket: "my-bucket", glob: "path/to/my/file.ext"</tt></li>
 			<li><tt>s3FindFiles bucket: "my-bucket", path: "path/to", glob: "my/file.ext"</tt></li>
-			<li><tt>s3FindFiles bucket: "my-bucket", path: "path/to/", glob: "my/file.ext"</tt></li>
+			<li><tt>s3FindFiles bucket: "my-bucket", path: "path/to/my", glob: "file.ext"</tt></li>
 		</ul>
 	</p>
 	<p>

--- a/src/test/java/de/taimos/pipeline/aws/FileWrapperTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/FileWrapperTest.java
@@ -1,0 +1,79 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileWrapperTest {
+	@Test
+	public void constructorWorksAsExpected() throws Exception {
+		FileWrapper file = null;
+
+		// Test a normal file.
+		file = new FileWrapper( "my-name", "my-path", false, 12, 9000 );
+		Assert.assertEquals( "my-name", file.getName() );
+		Assert.assertEquals( "my-path", file.getPath() );
+		Assert.assertFalse( file.isDirectory() );
+		Assert.assertEquals( 12, file.getLength() );
+		Assert.assertEquals( 9000, file.getLastModified() );
+
+		// Test a directory.
+		// Note that if we tell it that it is a directory, then it will append
+		// a trailing "/" to the path if one isn't there already.
+		file = new FileWrapper( "my-name", "my-path", true, 12, 9000 );
+		Assert.assertEquals( "my-name", file.getName() );
+		Assert.assertEquals( "my-path/", file.getPath() );
+		Assert.assertTrue( file.isDirectory() );
+		Assert.assertEquals( 12, file.getLength() );
+		Assert.assertEquals( 9000, file.getLastModified() );
+
+		// Test a directory that already has a trailing "/".
+		file = new FileWrapper( "my-name", "my-path/", true, 12, 9000 );
+		Assert.assertEquals( "my-name", file.getName() );
+		Assert.assertEquals( "my-path/", file.getPath() );
+		Assert.assertTrue( file.isDirectory() );
+		Assert.assertEquals( 12, file.getLength() );
+		Assert.assertEquals( 9000, file.getLastModified() );
+	}
+
+	@Test
+	public void pathIsUsedInAStringContext() throws Exception {
+		FileWrapper file = null;
+
+		// Test a normal file.
+		file = new FileWrapper( "my-name", "my-path", false, 12, 9000 );
+		Assert.assertEquals( "my-path", file.toString() );
+
+		// Test a directory.
+		// Note that if we tell it that it is a directory, then it will append
+		// a trailing "/" to the path if one isn't there already.
+		file = new FileWrapper( "my-name", "my-path", true, 12, 9000 );
+		Assert.assertEquals( "my-path/", file.toString() );
+
+		// Test a directory that already has a trailing "/".
+		file = new FileWrapper( "my-name", "my-path/", true, 12, 9000 );
+		Assert.assertEquals( "my-path/", file.toString() );
+	}
+}

--- a/src/test/java/de/taimos/pipeline/aws/S3FindFilesStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3FindFilesStepTest.java
@@ -21,10 +21,14 @@
 
 package de.taimos.pipeline.aws;
 
+import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Date;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 public class S3FindFilesStepTest {
 	@Test
@@ -76,5 +80,81 @@ public class S3FindFilesStepTest {
 		Assert.assertTrue( step.isOnlyFiles() );
 		step.setOnlyFiles( false );
 		Assert.assertFalse( step.isOnlyFiles() );
+	}
+
+	@Test
+	public void computeMatcherString() throws Exception {
+		String matcherString = null;
+		matcherString = S3FindFilesStep.Execution.computeMatcherString( "", "" );
+		Assert.assertEquals( "glob:*", matcherString );
+		matcherString = S3FindFilesStep.Execution.computeMatcherString( "path", "file.*" );
+		Assert.assertEquals( "glob:path/file.*", matcherString );
+		matcherString = S3FindFilesStep.Execution.computeMatcherString( "", "file.*" );
+		Assert.assertEquals( "glob:file.*", matcherString );
+		matcherString = S3FindFilesStep.Execution.computeMatcherString( "path/to", "my/**/file.*" );
+		Assert.assertEquals( "glob:path/to/my/**/file.*", matcherString );
+	}
+
+	@Test
+	public void createFileWrapperFromFolder() throws Exception {
+		FileWrapper file = null;
+
+		file = S3FindFilesStep.Execution.createFileWrapperFromFolder( 0, Paths.get("path/to/folder") );
+		Assert.assertEquals( "folder", file.getName() );
+		Assert.assertEquals( "path/to/folder/", file.getPath() );
+		Assert.assertTrue( file.isDirectory() );
+		Assert.assertEquals( 0, file.getLength() );
+		Assert.assertEquals( 0, file.getLastModified() );
+		file = S3FindFilesStep.Execution.createFileWrapperFromFolder( 0, Paths.get("path/to/folder/") );
+		Assert.assertEquals( "folder", file.getName() );
+		Assert.assertEquals( "path/to/folder/", file.getPath() );
+		Assert.assertTrue( file.isDirectory() );
+		Assert.assertEquals( 0, file.getLength() );
+		Assert.assertEquals( 0, file.getLastModified() );
+
+		file = S3FindFilesStep.Execution.createFileWrapperFromFolder( 1, Paths.get("path/to/folder") );
+		Assert.assertEquals( "folder", file.getName() );
+		Assert.assertEquals( "to/folder/", file.getPath() );
+		Assert.assertTrue( file.isDirectory() );
+		Assert.assertEquals( 0, file.getLength() );
+		Assert.assertEquals( 0, file.getLastModified() );
+
+		file = S3FindFilesStep.Execution.createFileWrapperFromFolder( 2, Paths.get("path/to/folder") );
+		Assert.assertEquals( "folder", file.getName() );
+		Assert.assertEquals( "folder/", file.getPath() );
+		Assert.assertTrue( file.isDirectory() );
+		Assert.assertEquals( 0, file.getLength() );
+		Assert.assertEquals( 0, file.getLastModified() );
+	}
+
+	@Test
+	public void createFileWrapperFromFile() throws Exception {
+		FileWrapper file = null;
+		S3ObjectSummary s3ObjectSummary = new S3ObjectSummary();
+		s3ObjectSummary.setBucketName( "my-bucket" );
+		s3ObjectSummary.setKey( "path/to/my/file.ext" );
+		s3ObjectSummary.setLastModified( new Date( 9000 ) );
+		s3ObjectSummary.setSize( 12 );
+
+		file = S3FindFilesStep.Execution.createFileWrapperFromFile( 0, Paths.get( s3ObjectSummary.getKey() ), s3ObjectSummary );
+		Assert.assertEquals( "file.ext", file.getName() );
+		Assert.assertEquals( "path/to/my/file.ext", file.getPath() );
+		Assert.assertFalse( file.isDirectory() );
+		Assert.assertEquals( 12, file.getLength() );
+		Assert.assertEquals( 9000, file.getLastModified() );
+
+		file = S3FindFilesStep.Execution.createFileWrapperFromFile( 1, Paths.get( s3ObjectSummary.getKey() ), s3ObjectSummary );
+		Assert.assertEquals( "file.ext", file.getName() );
+		Assert.assertEquals( "to/my/file.ext", file.getPath() );
+		Assert.assertFalse( file.isDirectory() );
+		Assert.assertEquals( 12, file.getLength() );
+		Assert.assertEquals( 9000, file.getLastModified() );
+
+		file = S3FindFilesStep.Execution.createFileWrapperFromFile( 2, Paths.get( s3ObjectSummary.getKey() ), s3ObjectSummary );
+		Assert.assertEquals( "file.ext", file.getName() );
+		Assert.assertEquals( "my/file.ext", file.getPath() );
+		Assert.assertFalse( file.isDirectory() );
+		Assert.assertEquals( 12, file.getLength() );
+		Assert.assertEquals( 9000, file.getLastModified() );
 	}
 }

--- a/src/test/java/de/taimos/pipeline/aws/S3FindFilesStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3FindFilesStepTest.java
@@ -1,0 +1,80 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3FindFilesStepTest {
+	@Test
+	public void gettersWorkAsExpected() throws Exception {
+		S3FindFilesStep step = new S3FindFilesStep( "my-bucket" );
+		Assert.assertEquals( "my-bucket", step.getBucket() );
+	}
+
+	@Test
+	public void defaultPathIsEmpty() throws Exception {
+		S3FindFilesStep step = new S3FindFilesStep( "my-bucket" );
+		Assert.assertEquals( "", step.getPath() );
+	}
+
+	@Test
+	public void pathCanBeSet() throws Exception {
+		S3FindFilesStep step = new S3FindFilesStep( "my-bucket" );
+		step.setPath( "path1" );
+		Assert.assertEquals( "path1", step.getPath() );
+		step.setPath( "path2" );
+		Assert.assertEquals( "path2", step.getPath() );
+	}
+
+	@Test
+	public void defaultGlobIsEmpty() throws Exception {
+		S3FindFilesStep step = new S3FindFilesStep( "my-bucket" );
+		Assert.assertEquals( "", step.getGlob() );
+	}
+
+	@Test
+	public void globCanBeSet() throws Exception {
+		S3FindFilesStep step = new S3FindFilesStep( "my-bucket" );
+		step.setGlob( "glob1" );
+		Assert.assertEquals( "glob1", step.getGlob() );
+		step.setGlob( "glob2" );
+		Assert.assertEquals( "glob2", step.getGlob() );
+	}
+
+	@Test
+	public void defaultOnlyFilesIsFalse() throws Exception {
+		S3FindFilesStep step = new S3FindFilesStep( "my-bucket" );
+		Assert.assertFalse( step.isOnlyFiles() );
+	}
+
+	@Test
+	public void onlyFilesCanBeSet() throws Exception {
+		S3FindFilesStep step = new S3FindFilesStep( "my-bucket" );
+		step.setOnlyFiles( true );
+		Assert.assertTrue( step.isOnlyFiles() );
+		step.setOnlyFiles( false );
+		Assert.assertFalse( step.isOnlyFiles() );
+	}
+}


### PR DESCRIPTION
One of the things that's missing here is the ability to _query_ S3 for what's already there.  Jenkins already has a step called `findFiles` that is provided by the `pipeline-utility-steps-plugin` plugin.  This code adds analogous functionality via `s3FindFiles`, even returning the same data structure.

From `s3FindFiles` in the README:

---

This provides a way to query the files/folders in the S3 bucket, analogous to the `findFiles` step provided by "pipeline-utility-steps-plugin".
If specified, the `path` limits the scope of the operation to that folder only.
The `glob` parameter tells `s3FindFiles` what to look for.  This can be a file name, a full path to a file, or a standard glob ("\*", "\*.ext", "path/\*\*/file.ext", etc.).

If you do not specify `path`, then it will default to the root of the bucket.
The path is assumed to be a folder; you do not need to end it with a "/", but it is okay if you do.

If you do not specify `glob`, then it will default to "\*".

By default, this will return both files and folders.
To only return files, set the `onlyFiles` parameter to `true`.

```
files = s3FindFiles(bucket:'my-bucket')
files = s3FindFiles(bucket:'my-bucket', glob:'path/to/targetFolder/file.ext')
files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'file.ext')
files = s3FindFiles(bucket:'my-bucket', path:'path/to/targetFolder', glob:'*.ext')
files = s3FindFiles(bucket:'my-bucket', path:'path', glob:'**/file.ext')
```

`s3FindFiles` returns an array of `FileWrapper` objects exactly identical to those returned by `findFiles`.

Each `FileWrapper` object has the following properties:

* `name`: the filename portion of the path (for "path/to/my/file.ext", this would be "file.ext")
* `path`: the full path of the file (for "path/to/my/file.ext", this would be "path/to/my/file.ext")
* `directory`: true if this is a directory; false otherwise
* `length`: the length of the file (this is always "0" for directories)
* `lastModified`: the last modification timestamp, in milliseconds since the Unix epoch (this is always "0" for directories)

When used in a string context, a `FileWrapper` object returns the value of its `path`.