### PR TITLE
Do not show S3's fake folders as files in `s3FindFiles`

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/S3FindFilesStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3FindFilesStep.java
@@ -217,6 +217,16 @@ public class S3FindFilesStep extends AbstractStepImpl {
 					while( true ) {
 						// Add any real objects to the list of objects to delete.
 						for( S3ObjectSummary entry : objectListing.getObjectSummaries() ) {
+							// S3 does this sneaky thing with folders created in the management console:
+							// It *actually* creates a zero-length file whose name ends in "/".
+							//
+							// Here, we're going to quietly skip those entries; they'll be handled normally
+							// by the folder pathway below, anyway.  (Yes, they are returned as actual s3
+							// entities as well as prefixes).
+							if( entry.getKey().endsWith("/") ) {
+								continue;
+							}
+
 							Path javaPath = Paths.get(entry.getKey());
 							if( matcher.matches( javaPath ) ) {
 								FileWrapper file = createFileWrapperFromFile( pathComponentCount, javaPath, entry );


### PR DESCRIPTION
Basically, AWS lets you create anything with any name; it's a key/value filestore. However, the convention (including in the S3 Management Console) is that "/" is a name delimiter for paths.  Anywhere that a key ends in "/", it is considered a "folder", even if it is only a virtual one (through the "prefix" logic).

Now, if you create a folder through the console, it creates a zero-length file whose name ends with "/".  Thus, the console sees it as an empty folder, even though it is really a zero-length file.

Here, I excluded those objects entirely.  They will never be returned as "files" from `s3FindFiles`.  They will, however, continue to show up as folders.