### PR TITLE
SessionName too long in case of long JobName

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/RoleSessionNameBuilder.java
+++ b/src/main/java/de/taimos/pipeline/aws/RoleSessionNameBuilder.java
@@ -1,0 +1,39 @@
+package de.taimos.pipeline.aws;
+
+import com.google.common.base.Joiner;
+
+final class RoleSessionNameBuilder {
+    private static final int ROLE_SESSION_NAME_MAX_LENGTH = 64;
+    private static final String SESSION_NAME_PREFIX = "Jenkins";
+    private static final int NUMBER_OF_SEPARATORS = 2;
+    private final String jobName;
+    private String buildNumber;
+
+    private RoleSessionNameBuilder(String jobName) {
+        this.jobName = jobName;
+    }
+
+    String build() {
+        final String jobNameWithoutWhitespaces = jobName.replace(" ", "");
+        final String jobNameWithoutSlashes = jobNameWithoutWhitespaces.replace("/", "-");
+
+        final int maxJobNameLength = ROLE_SESSION_NAME_MAX_LENGTH - (SESSION_NAME_PREFIX.length() + buildNumber.length() + NUMBER_OF_SEPARATORS);
+
+        final int jobNameLength = jobNameWithoutSlashes.length();
+        String finalJobName = jobNameWithoutSlashes;
+        if (jobNameLength > maxJobNameLength) {
+            finalJobName = jobNameWithoutSlashes.substring(0, maxJobNameLength);
+        }
+        return Joiner.on("-").join(SESSION_NAME_PREFIX, finalJobName, this.buildNumber);
+    }
+
+    static RoleSessionNameBuilder withJobName(final String jobName) {
+        return new RoleSessionNameBuilder(jobName);
+    }
+
+    RoleSessionNameBuilder withBuildNumber(final String buildNumber) {
+        this.buildNumber = buildNumber;
+        return this;
+    }
+}
+

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -242,8 +242,10 @@ public class WithAWSStep extends AbstractStepImpl {
 		}
 		
 		private String createRoleSessionName() {
-			String job_name = this.envVars.get("JOB_NAME").replace(" ", "").replace("/", "-");
-			return "Jenkins-" + job_name + "-" + this.envVars.get("BUILD_NUMBER");
+			return RoleSessionNameBuilder
+					.withJobName(this.envVars.get("JOB_NAME"))
+					.withBuildNumber(this.envVars.get("BUILD_NUMBER"))
+					.build();
 		}
 		
 		@Override

--- a/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
@@ -1,0 +1,60 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RoleSessionNameBuilderTest {
+	@Test
+	public void shortNamesAreNotStripped() throws Exception {
+		String shortJobName = "shortName";
+		String buildNumber = "1";
+		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder
+				.withJobName(shortJobName)
+				.withBuildNumber(buildNumber);
+		final String result = roleSessionNameBuilder.build();
+		assertEquals("roleSessionNameBuilder should not be strapped", "Jenkins-shortName-1", result);
+	}
+
+	@Test
+	public void nameLongerThanAWSLimitAreStripped() throws Exception {
+		String jobName = org.apache.commons.lang.StringUtils.repeat("s", 64);
+		String buildNumber = "123";
+		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder.withJobName(jobName)
+				.withBuildNumber(buildNumber);
+		final String result = roleSessionNameBuilder.build();
+		assertEquals("The result should be equal to the limit", 64, result.length());
+	}
+
+	@Test
+	public void nameEqualToAWSLimitAreStripped() throws Exception {
+		String jobName = org.apache.commons.lang.StringUtils.repeat("s", 52);
+		String buildNumber = "123";
+		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder.withJobName(jobName)
+				.withBuildNumber(buildNumber);
+		final String result = roleSessionNameBuilder.build();
+		assertEquals("The result should be equal to the limit", 64, result.length());
+	}
+
+}


### PR DESCRIPTION
Hi,

Thank you for contributing this plugin to open source. When using the latest release, I started to get an exception on building my job, stating that the roleSessionName is longer than 64 chars.

When creating Multibranch pipeline jobs, the job name is automatically set to the branchname. As the RoleSessionName contains job name it often ends up being longer than 64 chars which is the limit from AWS assumeRole API.
 
This pull request contains RoleSessionNameBuilder, that verifies the jobName length and strips the extra-characters to get 64 length String, a unit test and I successfully verified it on our Jenkins instance.

Looking forward to the new release.

Thanks,
Nune