### PR TITLE
Better errors for missing DescribeStacks

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -58,7 +58,7 @@ public class CloudFormationStack {
 			DescribeStacksResult result = this.client.describeStacks(new DescribeStacksRequest().withStackName(this.stack));
 			return !result.getStacks().isEmpty();
 		} catch (AmazonCloudFormationException e) {
-			if ("AccessDenied".compareTo(e.getErrorCode()) == 0) {
+			if ("AccessDenied".equals(e.getErrorCode())) {
 				this.listener.getLogger().format("Got error from describeStacks: %s\n", e.getErrorMessage());
 				throw e;
 			}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -58,6 +58,10 @@ public class CloudFormationStack {
 			DescribeStacksResult result = this.client.describeStacks(new DescribeStacksRequest().withStackName(this.stack));
 			return !result.getStacks().isEmpty();
 		} catch (AmazonCloudFormationException e) {
+			if ("AccessDenied".compareTo(e.getErrorCode()) == 0) {
+				this.listener.getLogger().format("Got error from describeStacks: %s\n", e.getErrorMessage());
+				throw e;
+			}
 			return false;
 		}
 	}


### PR DESCRIPTION
When the IAM permission for cloudformation:DescribeStacks
is missing, the plugin will try a create instead of
update. This code changes tries to avoid that, and
instead warn that it was not able to check if the
stack exists because of missing permissions.

Signed-off-by: Elliot Murphy <elliot@elliotmurphy.com>