### PR TITLE
S3 canned ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Specific metadatas can be add to upload files
 s3Upload(bucket:"my-bucket", path:'path/to/targetFolder/', includePathPattern:'**/*.svg', workingDir:'dist', metadatas:['Content-type:image/svg+xml','Another:Value'])
 ```
 
+Canned ACLs can be add to upload requests.
+
+```
+s3Upload(file:'file.txt', bucket:'my-bucket', path:'path/to/target/file.txt', acl:'PublicRead')
+s3Upload(file:'someFolder', bucket:'my-bucket', path:'path/to/targetFolder/', acl:'BucketOwnerFullControl')
+```
+
 ## s3Download
 
 Download a file/folder from S3 to the local workspace.
@@ -310,7 +317,7 @@ def idp = updateIdP(name: 'nameToCreateOrUpdate', metadata: 'pathToMetadataFile'
 # Changelog
 
 ## 1.15 (master)
-* Add the following options to `S3Upload` : `workingDir`, `includePathPattern`, `excludePathPattern` and `metadatas`
+* Add the following options to `S3Upload` : `workingDir`, `includePathPattern`, `excludePathPattern`, `metadatas` and `acl`
 
 ## 1.14
 * fixes JENKINS-45964: Assuming Role does not work in AWS-China

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
@@ -21,4 +21,16 @@
 	<f:entry title="${%Metadatas}" field="metadatas">
 		<f:tab />
 	</f:entry>
+	<f:entry title="${%ACL}" field="acl" name="acl">
+        <select name="acl">
+            <option value="Private">Private</option>
+            <option value="PublicRead">PublicRead</option>
+            <option value="PublicReadWrite">PublicReadWrite</option>
+            <option value="AuthenticatedRead">AuthenticatedRead</option>
+            <option value="LogDeliveryWrite">LogDeliveryWrite</option>
+            <option value="BucketOwnerRead">BucketOwnerRead</option>
+            <option value="BucketOwnerFullControl">BucketOwnerFullControl</option>
+            <option value="AwsExecRead">AwsExecRead</option>
+        </select>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-acl.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-acl.html
@@ -1,0 +1,15 @@
+<div>
+    <p>
+        Canned ACL to add to the upload request.
+        <ul>
+            <li>Private : Specifies the owner is granted Full Control. No one else has access rights. This is the default access control policy for any new buckets or objects.</li>
+            <li>PublicRead : Specifies the owner is granted Full Control and to the All Users group grantee is granted Read access.</li>
+            <li>PublicReadWrite: Specifies the owner is granted Full Control and to the All Users group grantee is granted Read and Write access.</li>
+            <li>AuthenticatedRead: Specifies the owner is granted Full Control and to the Authenticated Users group grantee is granted Read access.</li>
+            <li>LogDeliveryWrite: Specifies the owner is granted Full Control and to the Log Delivery group grantee is granted Write access.</li>
+            <li>BucketOwnerRead: Specifies the owner of the bucket, but not necessarily the same as the owner of the object, is granted Read access.</li>
+            <li>BucketOwnerFullControl: Specifies the owner of the bucket, but not necessarily the same as the owner of the object, is granted Full Control.</li>
+            <li>AwsExecRead: Specifies the owner is granted Full Control and Amazon EC2 is granted {@link Permission#Read} access to GET an Amazon Machine Image (AMI) bundle from Amazon S3.</li>
+        </ul>
+    </p>
+</div>

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -21,6 +21,7 @@
 
 package de.taimos.pipeline.aws;
 
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,8 +30,10 @@ public class S3UploadStepTest {
 	public void gettersWorkAsExpectedForFileCase() throws Exception {
 		S3UploadStep step = new S3UploadStep( "my-bucket" );
 		step.setFile( "my-file" );
+		step.setAcl(CannedAccessControlList.PublicRead);
 		Assert.assertEquals( "my-file", step.getFile() );
 		Assert.assertEquals( "my-bucket", step.getBucket() );
+		Assert.assertEquals( CannedAccessControlList.PublicRead, step.getAcl() );
 	}
 	
 	@Test


### PR DESCRIPTION
Sometimes, when the upload to the S3 buckets was performed by an user/role in another AWS Account via cross-account bucket permissions, is necessary to configure the Cannel ACL in the upload request.
For further information please see the following links:

- http://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html

- http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html

- https://stackoverflow.com/questions/22944054/cant-download-files-uploaded-by-shared-account-s3-bucket