### PR TITLE
allow to specify a federatedUserId - used for cloudtrail auditing of actions of jenkins users

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ def idp = updateIdP(name: 'nameToCreateOrUpdate', metadata: 'pathToMetadataFile'
 # Changelog
 
 ## 1.16 (master)
+* Add federatedUserId for withAWS support - generates temporary aws credentials for federated user which gets logged in CloudTrail 
 
 ## 1.15
 * Add the following options to `S3Upload` : `workingDir`, `includePathPattern`, `excludePathPattern`, `metadatas` and `acl`

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ withAWS(role:'admin', roleAccount:'123456789012', externalId: 'my-external-id') 
 }
 ```
 
+Assume federated user id information (federatedUserId is optional - if specified it generates a set of temporary credentials and allows you to push a federated user id into cloud trail for auditing):
+
+```
+withAWS(region:'eu-central-1',credentials:'nameOfSystemCredentials',federatedUserId:"${submitter}@${releaseVersion}") {
+    // do something
+}
+```
+
 ## awsIdentity
 
 Print current AWS identity information to the log.

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -73,7 +73,7 @@ public class WithAWSStep extends AbstractStepImpl {
 	private String federatedUserId = "";
 
 	public String getFederatedUserId() {
-		return federatedUserId;
+		return this.federatedUserId;
 	}
 
 	@DataBoundSetter

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -52,6 +52,8 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
+import com.amazonaws.services.securitytoken.model.GetFederationTokenRequest;
+import com.amazonaws.services.securitytoken.model.GetFederationTokenResult;
 import com.amazonaws.util.StringUtils;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
@@ -68,6 +70,16 @@ public class WithAWSStep extends AbstractStepImpl {
 	private String profile = "";
 	private String credentials = "";
 	private String externalId = "";
+	private String federatedUserId = "";
+
+	public String getFederatedUserId() {
+		return federatedUserId;
+	}
+
+	@DataBoundSetter
+	public void setFederatedUserId(String federatedUserId) {
+		this.federatedUserId = federatedUserId;
+	}
 
 	@DataBoundConstructor
 	public WithAWSStep() {
@@ -185,6 +197,7 @@ public class WithAWSStep extends AbstractStepImpl {
 			this.withProfile(awsEnv);
 			this.withRegion(awsEnv);
 			this.withRole(awsEnv);
+			this.withFederatedUserId(awsEnv);
 
 			EnvironmentExpander expander = new EnvironmentExpander() {
 				@Override
@@ -197,6 +210,30 @@ public class WithAWSStep extends AbstractStepImpl {
 					.withCallback(BodyExecutionCallback.wrap(this.getContext()))
 					.start();
 			return false;
+		}
+
+		
+		private final String ALLOW_ALL_POLICY = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"*\","
+				 + "\"Effect\":\"Allow\",\"Resource\":\"*\"}]}";
+		
+		private void withFederatedUserId(@Nonnull EnvVars localEnv) {
+			if (!StringUtils.isNullOrEmpty(this.step.getFederatedUserId())) {
+				AWSSecurityTokenServiceClient sts = AWSClientFactory.create(AWSSecurityTokenServiceClient.class, this.envVars);
+
+				GetFederationTokenRequest getFederationTokenRequest = new GetFederationTokenRequest();
+				getFederationTokenRequest.setDurationSeconds(3600);
+				getFederationTokenRequest.setName(this.step.getFederatedUserId());
+				getFederationTokenRequest.setPolicy(ALLOW_ALL_POLICY);
+				
+				GetFederationTokenResult federationTokenResult = sts.getFederationToken(getFederationTokenRequest);
+
+				Credentials credentials = federationTokenResult.getCredentials();
+				localEnv.override(AWSClientFactory.AWS_ACCESS_KEY_ID, credentials.getAccessKeyId());
+				localEnv.override(AWSClientFactory.AWS_SECRET_ACCESS_KEY, credentials.getSecretAccessKey());
+				localEnv.override(AWSClientFactory.AWS_SESSION_TOKEN, credentials.getSessionToken());
+				this.envVars.overrideAll(localEnv);
+			}
+			
 		}
 
 		private void withCredentials(@Nonnull Run<?,?> run, @Nonnull EnvVars localEnv) {


### PR DESCRIPTION
Allows for use of temporary credentials in the withAWS command where the federated user id is supplied. This gets passed into cloudtrail and allows for end to end auditing of the jenkins user who performed the approval (or triggered the build). 



* **What is the current behavior?** (You can also link to an open issue here)

Not applicable

* **What is the new behavior (if this is a feature change)?**

extend withAWS to supply a federatedUserId field and get that pushed into cloudtrail

Now cloudtrail looks as follows

"userIdentity": {
        "type": "FederatedUser",
        "principalId": "xxxxxx:<federatedUserId>",
        "arn": "arn:aws:sts::xxxxxx:federated-user/<federatedUserId>",


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)

No - fully backward compatible

* **Other information**: