### PR TITLE
add cache control to s3 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Specific metadatas can be add to upload files
 s3Upload(bucket:"my-bucket", path:'path/to/targetFolder/', includePathPattern:'**/*.svg', workingDir:'dist', metadatas:['Content-type:image/svg+xml','Another:Value'])
 ```
 
+Specific cachecontrol can be add to upload files
+
+```
+s3Upload(bucket:"my-bucket", path:'path/to/targetFolder/', includePathPattern:'**/*.svg', workingDir:'dist', cacheControl:'public,max-age=31536000')
+```
+
 Canned ACLs can be add to upload requests.
 
 ```
@@ -366,6 +372,7 @@ def result = invokeLambda(
 * Add return value to `awsIdentity` step
 * Add `ecrLogin` step
 * Add `invokeLambda` step
+* Add `cacheControl` to `s3Upload`step
 
 ## 1.15
 * Add the following options to `S3Upload` : `workingDir`, `includePathPattern`, `excludePathPattern`, `metadatas` and `acl`

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -21,27 +21,6 @@
 
 package de.taimos.pipeline.aws;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
-
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
-import org.jenkinsci.remoting.RoleChecker;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressEventType;
 import com.amazonaws.event.ProgressListener;
@@ -56,53 +35,97 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.google.common.base.Preconditions;
-
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.remoting.RoleChecker;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class S3UploadStep extends AbstractStepImpl {
-	
-	private String file;
+
 	private final String bucket;
+	private String file;
 	private String path = "";
 	private String includePathPattern;
 	private String excludePathPattern;
 	private String workingDir;
 	private String[] metadatas;
 	private CannedAccessControlList acl;
-	
+	private String cacheControl;
+
 	@DataBoundConstructor
 	public S3UploadStep(String bucket) {
 		this.bucket = bucket;
 	}
-	
+
 	public String getFile() {
 		return this.file;
 	}
-	
+
+	@DataBoundSetter
+	public void setFile(String file) {
+		this.file = file;
+	}
+
 	public String getBucket() {
 		return this.bucket;
 	}
-	
+
 	public String getPath() {
 		return this.path;
 	}
-	
+
+	@DataBoundSetter
+	public void setPath(String path) {
+		this.path = path;
+	}
+
 	public String getIncludePathPattern() {
 		return this.includePathPattern;
 	}
-	
+
+	@DataBoundSetter
+	public void setIncludePathPattern(String includePathPattern) {
+		this.includePathPattern = includePathPattern;
+	}
+
 	public String getExcludePathPattern() {
 		return this.excludePathPattern;
 	}
-	
+
+	@DataBoundSetter
+	public void setExcludePathPattern(String excludePathPattern) {
+		this.excludePathPattern = excludePathPattern;
+	}
+
 	public String getWorkingDir() {
 		return this.workingDir;
 	}
-	
+
+	@DataBoundSetter
+	public void setWorkingDir(String workingDir) {
+		this.workingDir = workingDir;
+	}
+
 	public String[] getMetadatas() {
 		if (this.metadatas != null) {
 			return this.metadatas.clone();
@@ -110,36 +133,7 @@ public class S3UploadStep extends AbstractStepImpl {
 			return null;
 		}
 	}
-	
-	public CannedAccessControlList getAcl() {
-		return this.acl;
-	}
-	
-	@DataBoundSetter
-	public void setFile(String file) {
-		this.file = file;
-	}
-	
-	@DataBoundSetter
-	public void setPath(String path) {
-		this.path = path;
-	}
-	
-	@DataBoundSetter
-	public void setIncludePathPattern(String includePathPattern) {
-		this.includePathPattern = includePathPattern;
-	}
-	
-	@DataBoundSetter
-	public void setExcludePathPattern(String excludePathPattern) {
-		this.excludePathPattern = excludePathPattern;
-	}
-	
-	@DataBoundSetter
-	public void setWorkingDir(String workingDir) {
-		this.workingDir = workingDir;
-	}
-	
+
 	@DataBoundSetter
 	public void setMetadatas(String[] metadatas) {
 		if (metadatas != null) {
@@ -148,32 +142,45 @@ public class S3UploadStep extends AbstractStepImpl {
 			this.metadatas = null;
 		}
 	}
-	
+public CannedAccessControlList getAcl() {
+		return acl;
+	}
 	@DataBoundSetter
 	public void setAcl(CannedAccessControlList acl) {
 		this.acl = acl;
 	}
-	
+
+	public String getCacheControl() {
+		return cacheControl;
+	}
+
+	@DataBoundSetter
+	public void setCacheControl(final String cacheControl) {
+		this.cacheControl = cacheControl;
+	}
+
+
 	@Extension
 	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
-		
+
 		public DescriptorImpl() {
 			super(Execution.class);
 		}
-		
+
 		@Override
 		public String getFunctionName() {
 			return "s3Upload";
 		}
-		
+
 		@Override
 		public String getDisplayName() {
 			return "Copy file to S3";
 		}
 	}
-	
+
 	public static class Execution extends AbstractStepExecutionImpl {
-		
+
+		private static final long serialVersionUID = 1L;
 		@Inject
 		private transient S3UploadStep step;
 		@StepContextParameter
@@ -182,7 +189,7 @@ public class S3UploadStep extends AbstractStepImpl {
 		private transient FilePath workspace;
 		@StepContextParameter
 		private transient TaskListener listener;
-		
+
 		@Override
 		public boolean start() throws Exception {
 			final String file = this.step.getFile();
@@ -193,7 +200,8 @@ public class S3UploadStep extends AbstractStepImpl {
 			final String workingDir = this.step.getWorkingDir();
 			final Map<String, String> metadatas = new HashMap<>();
 			final CannedAccessControlList acl = this.step.getAcl();
-			
+			final String cacheControl = this.step.getCacheControl();
+
 			if (this.step.getMetadatas() != null && this.step.getMetadatas().length != 0) {
 				for (String metadata : this.step.getMetadatas()) {
 					if (metadata.split(":").length == 2) {
@@ -201,11 +209,11 @@ public class S3UploadStep extends AbstractStepImpl {
 					}
 				}
 			}
-			
+
 			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
 			Preconditions.checkArgument(file != null || includePathPattern != null, "File or IncludePathPattern must not be null");
 			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be use together");
-			
+
 			final List<FilePath> children = new ArrayList<>();
 			final FilePath dir;
 			if (workingDir != null && !"".equals(workingDir.trim())) {
@@ -213,20 +221,20 @@ public class S3UploadStep extends AbstractStepImpl {
 			} else {
 				dir = this.workspace;
 			}
-			
-			if (file != null) {
+			if(file != null) {
 				children.add(dir.child(file));
-			} else if (excludePathPattern != null && !excludePathPattern.trim().isEmpty()) {
-				children.addAll(Arrays.asList(dir.list(includePathPattern, excludePathPattern, true)));
-			} else {
-				children.addAll(Arrays.asList(dir.list(includePathPattern, null, true)));
+			} else if (excludePathPattern != null && !excludePathPattern.trim().isEmpty()){
+					children.addAll(Arrays.asList(dir.list(includePathPattern, excludePathPattern, true)));
+				} else {
+					children.addAll(Arrays.asList(dir.list(includePathPattern, null, true)));
+
 			}
-			
+
 			new Thread("s3Upload") {
 				@Override
 				public void run() {
 					try {
-						if (children.size() == 1) {
+						if( children.size() == 1) {
 							FilePath child = children.get(0);
 							Execution.this.listener.getLogger().format("Uploading %s to s3://%s/%s %n", child.toURI(), bucket, path);
 							if (!child.exists()) {
@@ -234,18 +242,18 @@ public class S3UploadStep extends AbstractStepImpl {
 								Execution.this.getContext().onFailure(new FileNotFoundException(child.toURI().toString()));
 								return;
 							}
-							
-							child.act(new RemoteUploader(Execution.this.envVars, Execution.this.listener, bucket, path, metadatas, acl));
-							
+
+							child.act(new RemoteUploader(Execution.this.envVars, Execution.this.listener, bucket, path, metadatas, acl, cacheControl));
+
 							Execution.this.listener.getLogger().println("Upload complete");
 							Execution.this.getContext().onSuccess(null);
-						} else if (children.size() > 1) {
+						} else if( children.size() > 1) {
 							List<File> fileList = new ArrayList<File>();
 							Execution.this.listener.getLogger().format("Uploading %s to s3://%s/%s %n", includePathPattern, bucket, path);
-							for (FilePath child : children) {
+							for( FilePath child : children ) {
 								child.act(new FeedList(fileList));
 							}
-							dir.act(new RemoteListUploader(Execution.this.envVars, Execution.this.listener, fileList, bucket, path, metadatas, acl));
+							dir.act(new RemoteListUploader(Execution.this.envVars, Execution.this.listener, fileList, bucket, path, metadatas, acl, cacheControl));
 							Execution.this.listener.getLogger().println("Upload complete");
 							Execution.this.getContext().onSuccess(null);
 						}
@@ -256,34 +264,34 @@ public class S3UploadStep extends AbstractStepImpl {
 			}.start();
 			return false;
 		}
-		
+
 		@Override
 		public void stop(@Nonnull Throwable cause) throws Exception {
 			//
 		}
-		
-		private static final long serialVersionUID = 1L;
-		
+
 	}
-	
+
 	private static class RemoteUploader implements FilePath.FileCallable<Void> {
-		
+
 		private final EnvVars envVars;
 		private final TaskListener taskListener;
 		private final String bucket;
 		private final String path;
 		private final Map<String, String> metadatas;
 		private final CannedAccessControlList acl;
-		
-		RemoteUploader(EnvVars envVars, TaskListener taskListener, String bucket, String path, Map<String, String> metadatas, CannedAccessControlList acl) {
+		private final String cacheControl;
+
+		RemoteUploader(EnvVars envVars, TaskListener taskListener, String bucket, String path, Map<String, String> metadatas, CannedAccessControlList acl, String cacheControl) {
 			this.envVars = envVars;
 			this.taskListener = taskListener;
 			this.bucket = bucket;
 			this.path = path;
 			this.metadatas = metadatas;
 			this.acl = acl;
+			this.cacheControl = cacheControl;
 		}
-		
+
 		@Override
 		public Void invoke(File localFile, VirtualChannel channel) throws IOException, InterruptedException {
 			AmazonS3Client s3Client = AWSClientFactory.create(AmazonS3Client.class, this.envVars);
@@ -291,9 +299,14 @@ public class S3UploadStep extends AbstractStepImpl {
 			if (localFile.isFile()) {
 				Preconditions.checkArgument(this.path != null && !this.path.isEmpty(), "Path must not be null or empty when uploading file");
 				final Upload upload;
-				if (this.metadatas != null && this.metadatas.size() > 0) {
+				if ((this.metadatas != null && this.metadatas.size() > 0) || (this.cacheControl != null && !this.cacheControl.isEmpty())) {
 					ObjectMetadata metas = new ObjectMetadata();
-					metas.setUserMetadata(this.metadatas);
+					if (this.metadatas != null && this.metadatas.size() > 0) {
+						metas.setUserMetadata(this.metadatas);
+					}
+					if (this.cacheControl != null && !this.cacheControl.isEmpty()) {
+						metas.setCacheControl(this.cacheControl);
+					}
 					FileInputStream stream = new FileInputStream(localFile);
 					PutObjectRequest request = new PutObjectRequest(this.bucket, this.path, stream, metas);
 					if (this.acl != null) {
@@ -324,14 +337,18 @@ public class S3UploadStep extends AbstractStepImpl {
 				ObjectMetadataProvider metadatasProvider = new ObjectMetadataProvider() {
 					@Override
 					public void provideObjectMetadata(File file, ObjectMetadata meta) {
-						if (meta != null) {
-							if (RemoteUploader.this.metadatas != null && RemoteUploader.this.metadatas.size() > 0) {
+						if( meta != null ){
+							if( RemoteUploader.this.metadatas != null && RemoteUploader.this.metadatas.size() > 0 ) {
 								meta.setUserMetadata(RemoteUploader.this.metadatas);
 							}
 							if (RemoteUploader.this.acl != null) {
 								meta.setHeader(Headers.S3_CANNED_ACL, RemoteUploader.this.acl);
 							}
+							if (RemoteUploader.this.cacheControl != null && !RemoteUploader.this.cacheControl.isEmpty()) {
+								meta.setCacheControl(RemoteUploader.this.cacheControl);
+							}
 						}
+
 					}
 				};
 				fileUpload = mgr.uploadDirectory(this.bucket, this.path, localFile, true, metadatasProvider);
@@ -350,14 +367,14 @@ public class S3UploadStep extends AbstractStepImpl {
 			}
 			return null;
 		}
-		
+
 		@Override
 		public void checkRoles(RoleChecker roleChecker) throws SecurityException {
 		}
 	}
-	
+
 	private static class RemoteListUploader implements FilePath.FileCallable<Void> {
-		
+
 		private final EnvVars envVars;
 		private final TaskListener taskListener;
 		private final String bucket;
@@ -365,8 +382,9 @@ public class S3UploadStep extends AbstractStepImpl {
 		private final List<File> fileList;
 		private final Map<String, String> metadatas;
 		private final CannedAccessControlList acl;
-		
-		RemoteListUploader(EnvVars envVars, TaskListener taskListener, List<File> fileList, String bucket, String path, Map<String, String> metadatas, CannedAccessControlList acl) {
+		private final String cacheControl;
+
+		RemoteListUploader(EnvVars envVars, TaskListener taskListener, List<File> fileList, String bucket, String path, Map<String, String> metadatas, CannedAccessControlList acl, final String cacheControl) {
 			this.envVars = envVars;
 			this.taskListener = taskListener;
 			this.fileList = fileList;
@@ -374,8 +392,9 @@ public class S3UploadStep extends AbstractStepImpl {
 			this.path = path;
 			this.metadatas = metadatas;
 			this.acl = acl;
+			this.cacheControl = cacheControl;
 		}
-		
+
 		@Override
 		public Void invoke(File localFile, VirtualChannel channel) throws IOException, InterruptedException {
 			AmazonS3Client s3Client = AWSClientFactory.create(AmazonS3Client.class, this.envVars);
@@ -385,12 +404,15 @@ public class S3UploadStep extends AbstractStepImpl {
 			ObjectMetadataProvider metadatasProvider = new ObjectMetadataProvider() {
 				@Override
 				public void provideObjectMetadata(File file, ObjectMetadata meta) {
-					if (meta != null) {
-						if (RemoteListUploader.this.metadatas != null && RemoteListUploader.this.metadatas.size() > 0) {
+					if( meta != null ){
+						if( RemoteListUploader.this.metadatas != null && RemoteListUploader.this.metadatas.size() > 0 ) {
 							meta.setUserMetadata(RemoteListUploader.this.metadatas);
 						}
 						if (RemoteListUploader.this.acl != null) {
 							meta.setHeader(Headers.S3_CANNED_ACL, RemoteListUploader.this.acl);
+						}
+						if (RemoteListUploader.this.cacheControl != null && !RemoteListUploader.this.cacheControl.isEmpty()) {
+							meta.setCacheControl(RemoteListUploader.this.cacheControl);
 						}
 					}
 				}
@@ -409,30 +431,29 @@ public class S3UploadStep extends AbstractStepImpl {
 			fileUpload.waitForCompletion();
 			return null;
 		}
-		
+
 		@Override
 		public void checkRoles(RoleChecker roleChecker) throws SecurityException {
 		}
 	}
-	
+
 	private static class FeedList implements FilePath.FileCallable<Void> {
-		
+
 		private final List<File> fileList;
-		
+
 		FeedList(List<File> fileList) {
 			this.fileList = fileList;
 		}
-		
+
 		@Override
 		public Void invoke(File localFile, VirtualChannel channel) throws IOException, InterruptedException {
 			this.fileList.add(localFile);
 			return null;
 		}
-		
+
 		@Override
 		public void checkRoles(RoleChecker arg0) throws SecurityException {
 		}
 	}
-	
+
 }
-	

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
@@ -21,6 +21,9 @@
 	<f:entry title="${%Metadatas}" field="metadatas">
 		<f:tab />
 	</f:entry>
+	<f:entry title="${%CacheControl}" field="cacheControl">
+    		<f:tab />
+    	</f:entry>
 	<f:entry title="${%ACL}" field="acl" name="acl">
         <select name="acl">
             <option value="Private">Private</option>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-cachecontrol.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-cachecontrol.html
@@ -1,0 +1,4 @@
+<div>
+	Cache control to add to push file.
+	<i>Sample : "public,max-age=31536000"</i>
+</div>

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -31,9 +31,12 @@ public class S3UploadStepTest {
 		S3UploadStep step = new S3UploadStep( "my-bucket" );
 		step.setFile( "my-file" );
 		step.setAcl(CannedAccessControlList.PublicRead);
+		step.setCacheControl("my-cachecontrol");
 		Assert.assertEquals( "my-file", step.getFile() );
 		Assert.assertEquals( "my-bucket", step.getBucket() );
 		Assert.assertEquals( CannedAccessControlList.PublicRead, step.getAcl() );
+		Assert.assertEquals( "my-cachecontrol", step.getCacheControl() );
+
 	}
 	
 	@Test


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add cache control to S3 upload

* **What is the current behavior?** (You can also link to an open issue here)
Cache control on metadata is impossible to set

* **What is the new behavior (if this is a feature change)?**
Added cache control as field in the S3 upload call and passed field to the aws s3 upload sdk

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No breaking change