### PR TITLE
Added support for providing an additional policy when assuming a role through withAws.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ withAWS(profile:'myProfile') {
 }
 ```
 
-Assume role information (account is optional - uses current account as default, externalId is optional):
+Assume role information (account is optional - uses current account as default, externalId and policy are optional):
 
 ```
-withAWS(role:'admin', roleAccount:'123456789012', externalId: 'my-external-id') {
+withAWS(role:'admin', roleAccount:'123456789012', externalId: 'my-external-id', policy: '{"Version":"2012-10-17","Statement":[{"Sid":"Stmt1","Effect":"Deny","Action":"s3:DeleteObject","Resource":"*"}]}') {
     // do something
 }
 ```
@@ -367,7 +367,10 @@ def result = invokeLambda(
 
 # Changelog
 
-## 1.16 (master)
+## 1.17 (master)
+* Add policy for withAWS support - allows an additional policy to be combined with the policy associated with the assumed role. 
+
+## 1.16
 * Add federatedUserId for withAWS support - generates temporary aws credentials for federated user which gets logged in CloudTrail 
 * Add return value to `awsIdentity` step
 * Add `ecrLogin` step

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/config.jelly
@@ -18,6 +18,9 @@
 	<f:entry title="${%External ID}" field="externalId">
 		<f:textbox />
 	</f:entry>
+	<f:entry title="${%Policy}" field="policy">
+		<f:textbox />
+	</f:entry>
 	<f:entry title="${%Federated User ID}" field="federatedUserId">
 		<f:textbox />
 	</f:entry>

--- a/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-policy.html
+++ b/src/main/resources/de/taimos/pipeline/aws/WithAWSStep/help-policy.html
@@ -1,0 +1,3 @@
+<div>
+	(optional) An additional policy that is to be combined with the policy associated with the role.
+</div>


### PR DESCRIPTION
Adds an optional 'policy' attribute to 'withAws' that can be used to provide an additional policy document that will be combined with the policy associated with the role to assume.

This makes it possible impose additional restrictions to the assumed role as a safety measure.

This PR simply exposes existing AWS functionality.