### PR TITLE
Added create/execute change set support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This plugins adds Jenkins pipeline steps to interact with the AWS API.
 * [cfnDelete](#cfndelete)
 * [cfnDescribe](#cfndescribe)
 * [cfnExports](#cfnexports)
+* [cfnCreateChangeSet](#cfncreatechangeset)
+* [cfnExecuteChangeSet](#cfnexecutechangeset)
 * [snsPublish](#snspublish)
 * [deployAPI](#deployapi)
 * [awaitDeploymentCompletion](#awaitdeploymentcompletion)
@@ -268,6 +270,54 @@ The step returns the global CloudFormation exports as map.
 def globalExports = cfnExports()
 ```
 
+## cfnCreateChangeSet
+
+Create a change set to update the given CloudFormation stack using the given template from the workspace.
+You can specify an optional list of parameters.
+You can also specify a list of `keepParams` of parameters which will use the previous value on stack updates.
+
+If you have many parameters you can specify a `paramsFile` containing the parameters. The format is either a standard
+JSON file like with the cli or a YAML file for the [cfn-params](https://www.npmjs.com/package/cfn-params) command line utility.
+
+Additionally you can specify a list of tags that are set on the stack and all resources created by CloudFormation.
+The step returns the outputs of the stack as a map.
+
+To prevent running into rate limiting on the AWS API you can change the default polling interval of 1000 ms using the parameter `pollIntervall`. Using the value `0` disables event printing.
+
+```
+cfnCreateChangeSet(stack:'my-stack', changeSet:'my-change-set', file:'template.yaml', params:['InstanceType=t2.nano'], keepParams:['Version'], tags:['TagName=Value'], pollInterval:1000)
+```
+
+Alternatively, you can specify a URL to a template on S3 (you'll need this if you hit the 51200 byte limit on template):
+
+```
+cfnCreateChangeSet(stack:'my-stack', changeSet:'my-change-set', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml')
+```
+
+By default the `cfnCreateChangeSet` step creates a change set for creating a new stack if the specified stack does not exist, this behaviour can be overridden by passing `create: 'false'` as parameter :
+```
+cfnCreateChangeSet(stack:'my-stack', changeSet:'my-change-set', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', create: 'false')
+```
+In above example if `my-stack` already exists, a change set stack with change set will be created, and if it doesnt exist no actions would be performed.
+
+
+In a case where CloudFormation needs to use a different IAM Role for creating or updating the stack than the one currently in effect, you can pass the complete Role ARN to be used as `roleArn` parameter. i.e:
+```
+cfnCreateChangeSet(stack:'my-stack', changeSet:'my-change-set', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', roleArn: 'arn:aws:iam::123456789012:role/S3Access')
+```
+
+Note: When creating a change set for a non-existing stack, either `file` or `url` are required. When updating it, omitting both parameters will keep the stack's current template.
+
+## cfnExecuteChangeSet
+
+Execute a previously created change set to create or update a CloudFormation stack. All the necessary information, like parameters and tags, were provided earlier when the change set was created.
+
+To prevent running into rate limiting on the AWS API you can change the default polling interval of 1000 ms using the parameter `pollIntervall`. Using the value `0` disables event printing.
+
+```
+def outputs = cfnExecuteChangeSet(stack:'my-stack', changeSet:'my-change-set', pollInterval:1000)
+```
+
 ## snsPublish
 
 Publishes a message to SNS.
@@ -367,7 +417,11 @@ def result = invokeLambda(
 
 # Changelog
 
-## 1.16 (master)
+## 1.17 (master)
+* add `cfnCreateChangeSet` step
+* add `cfnExecuteChangeSet` step
+
+## 1.16
 * Add federatedUserId for withAWS support - generates temporary aws credentials for federated user which gets logged in CloudTrail 
 * Add return value to `awsIdentity` step
 * Add `ecrLogin` step

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateSetStep.java
@@ -1,0 +1,316 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws.cloudformation;
+
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.Tag;
+import com.google.common.base.Preconditions;
+import de.taimos.pipeline.aws.AWSClientFactory;
+import de.taimos.pipeline.aws.cloudformation.parser.JSONParameterFileParser;
+import de.taimos.pipeline.aws.cloudformation.parser.ParameterFileParser;
+import de.taimos.pipeline.aws.cloudformation.parser.YAMLParameterFileParser;
+import de.taimos.pipeline.aws.utils.IamRoleUtils;
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Collection;
+
+abstract class AbstractCFNCreateSetStep extends AbstractStepImpl {
+
+	private final String stack;
+	private String file;
+	private String url;
+	private String[] params;
+	private String[] keepParams;
+	private String[] tags;
+	private String paramsFile;
+	private Long pollInterval = 1000L;
+	private Boolean create = true;
+	private String roleArn;
+
+	public AbstractCFNCreateSetStep(String stack) {
+		this.stack = stack;
+	}
+	
+	public String getStack() {
+		return this.stack;
+	}
+	
+	public String getFile() {
+		return this.file;
+	}
+	
+	@DataBoundSetter
+	public void setFile(String file) {
+		this.file = file;
+	}
+	
+	public String getUrl() {
+		return this.url;
+	}
+	
+	@DataBoundSetter
+	public void setUrl(String url) {
+		this.url = url;
+	}
+	
+	public String[] getParams() {
+		return this.params != null ? this.params.clone() : null;
+	}
+	
+	@DataBoundSetter
+	public void setParams(String[] params) {
+		this.params = params.clone();
+	}
+	
+	public String[] getKeepParams() {
+		return this.keepParams != null ? this.keepParams.clone() : null;
+	}
+	
+	@DataBoundSetter
+	public void setKeepParams(String[] keepParams) {
+		this.keepParams = keepParams.clone();
+	}
+	
+	public String[] getTags() {
+		return this.tags != null ? this.tags.clone() : null;
+	}
+	
+	@DataBoundSetter
+	public void setTags(String[] tags) {
+		this.tags = tags.clone();
+	}
+	
+	public String getParamsFile() {
+		return this.paramsFile;
+	}
+	
+	@DataBoundSetter
+	public void setParamsFile(String paramsFile) {
+		this.paramsFile = paramsFile;
+	}
+
+	public Long getPollInterval() {
+		return this.pollInterval;
+	}
+	
+	@DataBoundSetter
+	public void setPollInterval(Long pollInterval) {
+		this.pollInterval = pollInterval;
+	}
+	
+	public Boolean getCreate() {
+		return create;
+	}
+	
+	@DataBoundSetter
+	public void setCreate(Boolean create) {
+		this.create = create;
+	}
+	
+	public String getRoleArn() {
+		return roleArn;
+	}
+	
+	@DataBoundSetter
+	public void setRoleArn(String roleArn) {
+		this.roleArn = roleArn;
+	}
+
+	abstract static class Execution extends AbstractStepExecutionImpl {
+
+		protected abstract AbstractCFNCreateSetStep getStep();
+		protected abstract EnvVars getEnvVars();
+		protected abstract FilePath getWorkspace();
+		protected abstract TaskListener getListener();
+
+		protected abstract void checkPreconditions();
+		protected abstract String getThreadName();
+		protected abstract Object whenStackExists(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception;
+		protected abstract Object whenStackMissing(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception;
+
+		private String getStack() {
+			return getStep().getStack();
+		}
+
+		private String getParamsFile() {
+			return getStep().getParamsFile();
+		}
+
+		private String[] getParams() {
+			return getStep().getParams();
+		}
+
+		private String[] getKeepParams() {
+			return getStep().getKeepParams();
+		}
+
+		private String[] getTags() {
+			return getStep().getTags();
+		}
+
+		private String getRoleArn() {
+			return getStep().getRoleArn();
+		}
+
+		private Boolean getCreate() {
+			return getStep().getCreate();
+		}
+
+		@Override
+		public boolean start() throws Exception {
+
+			final String stack = getStack();
+			final String roleArn = getRoleArn();
+			final Boolean create = getCreate();
+
+			final Collection<Parameter> params = this.parseParamsFile(getParamsFile());
+			params.addAll(this.parseParams(getParams()));
+
+			final Collection<Parameter> keepParams = this.parseKeepParams(getKeepParams());
+			final Collection<Tag> tags = this.parseTags(getTags());
+
+			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
+			Preconditions.checkArgument(roleArn == null || IamRoleUtils.validRoleArn(roleArn), "RoleArn must be a valid ARN.");
+
+			checkPreconditions();
+
+			new Thread(getThreadName()) {
+				@Override
+				public void run() {
+					try {
+						AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, getEnvVars());
+						CloudFormationStack cfnStack = new CloudFormationStack(client, stack, getListener());
+						if (cfnStack.exists()) {
+							ArrayList<Parameter> parameters = new ArrayList<>(params);
+							parameters.addAll(keepParams);
+							getContext().onSuccess(whenStackExists(parameters, tags));
+						} else if (create) {
+							getContext().onSuccess(whenStackMissing(params, tags));
+						} else {
+							getListener().getLogger().println("No stack found with the name and skipped creation due to configuration.");
+							getContext().onSuccess(null);
+						}
+					} catch (Exception e) {
+						getContext().onFailure(e);
+					}
+				}
+			}.start();
+			return false;
+		}
+
+		@Override
+		public void stop(@Nonnull Throwable throwable) throws Exception {
+
+		}
+
+		private Collection<Parameter> parseParamsFile(String paramsFile) {
+			try {
+				if (paramsFile == null || paramsFile.isEmpty()) {
+					return new ArrayList<>();
+				}
+				final ParameterFileParser parser;
+				if (paramsFile.endsWith(".json")) {
+					parser = new JSONParameterFileParser();
+				} else if (paramsFile.endsWith(".yaml")) {
+					parser = new YAMLParameterFileParser();
+				} else {
+					throw new RuntimeException("Invalid file extension for parameter file (supports json/yaml)");
+				}
+				return parser.parseParams(getWorkspace().child(paramsFile).read());
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		private Collection<Tag> parseTags(String[] tags) {
+			Collection<Tag> tagList = new ArrayList<>();
+			if (tags == null) {
+				return tagList;
+			}
+			for (String tag : tags) {
+				int i = tag.indexOf("=");
+				if (i < 0) {
+					throw new RuntimeException("Missing = in tag " + tag);
+				}
+				String key = tag.substring(0, i);
+				String value = tag.substring(i + 1);
+				tagList.add(new Tag().withKey(key).withValue(value));
+			}
+			return tagList;
+		}
+
+		private Collection<Parameter> parseParams(String[] params) {
+			Collection<Parameter> parameters = new ArrayList<>();
+			if (params == null) {
+				return parameters;
+			}
+			for (String param : params) {
+				int i = param.indexOf("=");
+				if (i < 0) {
+					throw new RuntimeException("Missing = in param " + param);
+				}
+				String key = param.substring(0, i);
+				String value = param.substring(i + 1);
+				parameters.add(new Parameter().withParameterKey(key).withParameterValue(value));
+			}
+			return parameters;
+		}
+
+		private Collection<Parameter> parseKeepParams(String[] params) {
+			Collection<Parameter> parameters = new ArrayList<>();
+			if (params == null) {
+				return parameters;
+			}
+			for (String param : params) {
+				parameters.add(new Parameter().withParameterKey(param).withUsePreviousValue(true));
+			}
+			return parameters;
+		}
+
+		protected CloudFormationStack getCfnStack() {
+			AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, getEnvVars());
+			return new CloudFormationStack(client, getStep().getStack(), getListener());
+		}
+
+		protected String readTemplate(String file) {
+			if (file == null) {
+				return null;
+			}
+
+			FilePath child = getWorkspace().child(file);
+			try {
+				return child.readToString();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
@@ -41,7 +41,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 
-abstract class AbstractCFNCreateSetStep extends AbstractStepImpl {
+abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 
 	private final String stack;
 	private String file;
@@ -54,7 +54,7 @@ abstract class AbstractCFNCreateSetStep extends AbstractStepImpl {
 	private Boolean create = true;
 	private String roleArn;
 
-	public AbstractCFNCreateSetStep(String stack) {
+	public AbstractCFNCreateStep(String stack) {
 		this.stack = stack;
 	}
 	
@@ -145,7 +145,7 @@ abstract class AbstractCFNCreateSetStep extends AbstractStepImpl {
 
 	abstract static class Execution extends AbstractStepExecutionImpl {
 
-		protected abstract AbstractCFNCreateSetStep getStep();
+		protected abstract AbstractCFNCreateStep getStep();
 		protected abstract EnvVars getEnvVars();
 		protected abstract FilePath getWorkspace();
 		protected abstract TaskListener getListener();

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
@@ -126,7 +126,7 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 	}
 	
 	public Boolean getCreate() {
-		return create;
+		return this.create;
 	}
 	
 	@DataBoundSetter
@@ -135,7 +135,7 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 	}
 	
 	public String getRoleArn() {
-		return roleArn;
+		return this.roleArn;
 	}
 	
 	@DataBoundSetter
@@ -156,69 +156,69 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 		protected abstract Object whenStackMissing(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception;
 
 		private String getStack() {
-			return getStep().getStack();
+			return this.getStep().getStack();
 		}
 
 		private String getParamsFile() {
-			return getStep().getParamsFile();
+			return this.getStep().getParamsFile();
 		}
 
 		private String[] getParams() {
-			return getStep().getParams();
+			return this.getStep().getParams();
 		}
 
 		private String[] getKeepParams() {
-			return getStep().getKeepParams();
+			return this.getStep().getKeepParams();
 		}
 
 		private String[] getTags() {
-			return getStep().getTags();
+			return this.getStep().getTags();
 		}
 
 		private String getRoleArn() {
-			return getStep().getRoleArn();
+			return this.getStep().getRoleArn();
 		}
 
 		private Boolean getCreate() {
-			return getStep().getCreate();
+			return this.getStep().getCreate();
 		}
 
 		@Override
 		public boolean start() throws Exception {
 
-			final String stack = getStack();
-			final String roleArn = getRoleArn();
-			final Boolean create = getCreate();
+			final String stack = this.getStack();
+			final String roleArn = this.getRoleArn();
+			final Boolean create = this.getCreate();
 
-			final Collection<Parameter> params = this.parseParamsFile(getParamsFile());
-			params.addAll(this.parseParams(getParams()));
+			final Collection<Parameter> params = this.parseParamsFile(this.getParamsFile());
+			params.addAll(this.parseParams(this.getParams()));
 
-			final Collection<Parameter> keepParams = this.parseKeepParams(getKeepParams());
-			final Collection<Tag> tags = this.parseTags(getTags());
+			final Collection<Parameter> keepParams = this.parseKeepParams(this.getKeepParams());
+			final Collection<Tag> tags = this.parseTags(this.getTags());
 
 			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
 			Preconditions.checkArgument(roleArn == null || IamRoleUtils.validRoleArn(roleArn), "RoleArn must be a valid ARN.");
 
-			checkPreconditions();
+			this.checkPreconditions();
 
 			new Thread(getThreadName()) {
 				@Override
 				public void run() {
 					try {
-						AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, getEnvVars());
-						CloudFormationStack cfnStack = new CloudFormationStack(client, stack, getListener());
+						AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, Execution.this.getEnvVars());
+						CloudFormationStack cfnStack = new CloudFormationStack(client, stack, Execution.this.getListener());
 						if (cfnStack.exists()) {
 							ArrayList<Parameter> parameters = new ArrayList<>(params);
 							parameters.addAll(keepParams);
-							getContext().onSuccess(whenStackExists(parameters, tags));
+							Execution.this.getContext().onSuccess(Execution.this.whenStackExists(parameters, tags));
 						} else if (create) {
-							getContext().onSuccess(whenStackMissing(params, tags));
+							Execution.this.getContext().onSuccess(Execution.this.whenStackMissing(params, tags));
 						} else {
-							getListener().getLogger().println("No stack found with the name and skipped creation due to configuration.");
-							getContext().onSuccess(null);
+							Execution.this.getListener().getLogger().println("No stack found with the name and skipped creation due to configuration.");
+							Execution.this.getContext().onSuccess(null);
 						}
 					} catch (Exception e) {
-						getContext().onFailure(e);
+						Execution.this.getContext().onFailure(e);
 					}
 				}
 			}.start();
@@ -243,7 +243,7 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 				} else {
 					throw new RuntimeException("Invalid file extension for parameter file (supports json/yaml)");
 				}
-				return parser.parseParams(getWorkspace().child(paramsFile).read());
+				return parser.parseParams(this.getWorkspace().child(paramsFile).read());
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}
@@ -295,8 +295,8 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 		}
 
 		protected CloudFormationStack getCfnStack() {
-			AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, getEnvVars());
-			return new CloudFormationStack(client, getStep().getStack(), getListener());
+			AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, this.getEnvVars());
+			return new CloudFormationStack(client, this.getStack(), this.getListener());
 		}
 
 		protected String readTemplate(String file) {
@@ -304,7 +304,7 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 				return null;
 			}
 
-			FilePath child = getWorkspace().child(file);
+			FilePath child = this.getWorkspace().child(file);
 			try {
 				return child.readToString();
 			} catch (Exception e) {

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
@@ -21,12 +21,10 @@
 
 package de.taimos.pipeline.aws.cloudformation;
 
-import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
 import com.amazonaws.services.cloudformation.model.ChangeSetType;
 import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Tag;
 import com.google.common.base.Preconditions;
-import de.taimos.pipeline.aws.AWSClientFactory;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -35,7 +33,6 @@ import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.Collection;
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
@@ -81,22 +81,22 @@ public class CFNCreateChangeSetStep extends AbstractCFNCreateStep {
 
 		@Override
 		public AbstractCFNCreateStep getStep() {
-			return step;
+			return this.step;
 		}
 
 		@Override
 		public EnvVars getEnvVars() {
-			return envVars;
+			return this.envVars;
 		}
 
 		@Override
 		public FilePath getWorkspace() {
-			return workspace;
+			return this.workspace;
 		}
 
 		@Override
 		public TaskListener getListener() {
-			return listener;
+			return this.listener;
 		}
 
 		@Override
@@ -115,8 +115,7 @@ public class CFNCreateChangeSetStep extends AbstractCFNCreateStep {
 			final String changeSet = this.step.getChangeSet();
 			final String file = this.step.getFile();
 			final String url = this.step.getUrl();
-			CloudFormationStack cfnStack = getCfnStack();
-			cfnStack.createChangeSet(changeSet, readTemplate(file), url, parameters, tags, getStep().getPollInterval(), ChangeSetType.UPDATE, getStep().getRoleArn());
+			this.getCfnStack().createChangeSet(changeSet, this.readTemplate(file), url, parameters, tags, this.getStep().getPollInterval(), ChangeSetType.UPDATE, this.getStep().getRoleArn());
 			return null;
 		}
 
@@ -125,7 +124,7 @@ public class CFNCreateChangeSetStep extends AbstractCFNCreateStep {
 			final String changeSet = this.step.getChangeSet();
 			final String file = this.step.getFile();
 			final String url = this.step.getUrl();
-			getCfnStack().createChangeSet(changeSet, readTemplate(file), url, parameters, tags, getStep().getPollInterval(), ChangeSetType.CREATE, getStep().getRoleArn());
+			this.getCfnStack().createChangeSet(changeSet, this.readTemplate(file), url, parameters, tags, this.getStep().getPollInterval(), ChangeSetType.CREATE, this.getStep().getRoleArn());
 			return null;
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
@@ -1,0 +1,321 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws.cloudformation;
+
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.ChangeSetType;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.Tag;
+import com.google.common.base.Preconditions;
+import de.taimos.pipeline.aws.AWSClientFactory;
+import de.taimos.pipeline.aws.cloudformation.parser.JSONParameterFileParser;
+import de.taimos.pipeline.aws.cloudformation.parser.ParameterFileParser;
+import de.taimos.pipeline.aws.cloudformation.parser.YAMLParameterFileParser;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CFNCreateChangeSetStep extends AbstractStepImpl {
+
+	private final String changeSet;
+	private final String stack;
+	private String file;
+	private String url;
+	private String[] params;
+	private String[] keepParams;
+	private String[] tags;
+	private String paramsFile;
+	private Long pollInterval = 1000L;
+	private Boolean create = true;
+
+	private String roleArn;
+
+	@DataBoundConstructor
+	public CFNCreateChangeSetStep(String changeSet, String stack) {
+		this.changeSet = changeSet;
+		this.stack = stack;
+	}
+
+	public String getChangeSet() {
+		return this.changeSet;
+	}
+
+	public String getStack() {
+		return this.stack;
+	}
+	
+	public String getFile() {
+		return this.file;
+	}
+	
+	@DataBoundSetter
+	public void setFile(String file) {
+		this.file = file;
+	}
+	
+	public String getUrl() {
+		return this.url;
+	}
+	
+	@DataBoundSetter
+	public void setUrl(String url) {
+		this.url = url;
+	}
+	
+	public String[] getParams() {
+		return this.params != null ? this.params.clone() : null;
+	}
+	
+	@DataBoundSetter
+	public void setParams(String[] params) {
+		this.params = params.clone();
+	}
+	
+	public String[] getKeepParams() {
+		return this.keepParams != null ? this.keepParams.clone() : null;
+	}
+	
+	@DataBoundSetter
+	public void setKeepParams(String[] keepParams) {
+		this.keepParams = keepParams.clone();
+	}
+	
+	public String[] getTags() {
+		return this.tags != null ? this.tags.clone() : null;
+	}
+	
+	@DataBoundSetter
+	public void setTags(String[] tags) {
+		this.tags = tags.clone();
+	}
+	
+	public String getParamsFile() {
+		return this.paramsFile;
+	}
+	
+	@DataBoundSetter
+	public void setParamsFile(String paramsFile) {
+		this.paramsFile = paramsFile;
+	}
+
+	public Long getPollInterval() {
+		return this.pollInterval;
+	}
+	
+	@DataBoundSetter
+	public void setPollInterval(Long pollInterval) {
+		this.pollInterval = pollInterval;
+	}
+
+	public Boolean getCreate() {
+		return create;
+	}
+
+	@DataBoundSetter
+	public void setCreate(Boolean create) {
+		this.create = create;
+	}
+
+	public String getRoleArn() {
+		return roleArn;
+	}
+
+	@DataBoundSetter
+	public void setRoleArn(String roleArn) {
+		this.roleArn = roleArn;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+		
+		public DescriptorImpl() {
+			super(Execution.class);
+		}
+		
+		@Override
+		public String getFunctionName() {
+			return "cfnCreateChangeSet";
+		}
+		
+		@Override
+		public String getDisplayName() {
+			return "Create CloudFormation change set";
+		}
+	}
+	
+	public static class Execution extends AbstractStepExecutionImpl {
+		
+		@Inject
+		private transient CFNCreateChangeSetStep step;
+		@StepContextParameter
+		private transient EnvVars envVars;
+		@StepContextParameter
+		private transient FilePath workspace;
+		@StepContextParameter
+		private transient TaskListener listener;
+		
+		@Override
+		public boolean start() throws Exception {
+			final String changeSet = this.step.getChangeSet();
+			final String stack = this.step.getStack();
+			final String file = this.step.getFile();
+			final String url = this.step.getUrl();
+			final Boolean create = this.step.getCreate();
+			final String roleArn = this.step.getRoleArn();
+
+			final Collection<Parameter> params= this.parseParamsFile(this.step.getParamsFile());
+			params.addAll(this.parseParams(this.step.getParams()));
+			
+			final Collection<Parameter> keepParams = this.parseKeepParams(this.step.getKeepParams());
+			final Collection<Tag> tags = this.parseTags(this.step.getTags());
+
+			Preconditions.checkArgument(changeSet != null && !changeSet.isEmpty(), "Change Set must not be null or empty");
+
+			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
+
+			new Thread("cfnCreateChangeSet-" + changeSet) {
+				@Override
+				public void run() {
+					try {
+						AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, Execution.this.envVars);
+						CloudFormationStack cfnStack = new CloudFormationStack(client, stack, Execution.this.listener);
+						if (cfnStack.exists()) {
+							Execution.this.listener.getLogger().format("Creating CloudFormation change set %s for existing stack %s %n", changeSet, stack);
+							ArrayList<Parameter> parameters = new ArrayList<>(params);
+							parameters.addAll(keepParams);
+							cfnStack.createChangeSet(changeSet, Execution.this.readTemplate(file), url, parameters, tags, Execution.this.step.getPollInterval(), ChangeSetType.UPDATE, roleArn);
+						} else if (create) {
+							Execution.this.listener.getLogger().format("Creating CloudFormation change set %s for new stack %s %n", changeSet, stack);
+							cfnStack.createChangeSet(changeSet, Execution.this.readTemplate(file), url, params, tags, Execution.this.step.getPollInterval(), ChangeSetType.CREATE, roleArn);
+						} else {
+							Execution.this.listener.getLogger().println("No stack found with the name and skipped change set creation due to configuration.");
+						}
+						Execution.this.listener.getLogger().println("Create change set complete");
+						Execution.this.getContext().onSuccess(cfnStack.describeOutputs());
+					} catch (Exception e) {
+						Execution.this.getContext().onFailure(e);
+					}
+				}
+			}.start();
+			return false;
+		}
+		
+		private Collection<Parameter> parseParamsFile(String paramsFile) {
+			try {
+				if (paramsFile == null || paramsFile.isEmpty()) {
+					return new ArrayList<>();
+				}
+				final ParameterFileParser parser;
+				if (paramsFile.endsWith(".json")) {
+					parser = new JSONParameterFileParser();
+				} else
+				if (paramsFile.endsWith(".yaml")) {
+					parser = new YAMLParameterFileParser();
+				} else {
+					throw new RuntimeException("Invalid file extension for parameter file (supports json/yaml)");
+				}
+				return parser.parseParams(this.workspace.child(paramsFile).read());
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		
+		private String readTemplate(String file) {
+			if (file == null) {
+				return null;
+			}
+			
+			FilePath child = this.workspace.child(file);
+			try {
+				return child.readToString();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+		
+		private Collection<Tag> parseTags(String[] tags) {
+			Collection<Tag> tagList = new ArrayList<>();
+			if (tags == null) {
+				return tagList;
+			}
+			for (String tag : tags) {
+				int i = tag.indexOf("=");
+				if (i < 0) {
+					throw new RuntimeException("Missing = in tag " + tag);
+				}
+				String key = tag.substring(0, i);
+				String value = tag.substring(i + 1);
+				tagList.add(new Tag().withKey(key).withValue(value));
+			}
+			return tagList;
+		}
+		
+		private Collection<Parameter> parseParams(String[] params) {
+			Collection<Parameter> parameters = new ArrayList<>();
+			if (params == null) {
+				return parameters;
+			}
+			for (String param : params) {
+				int i = param.indexOf("=");
+				if (i < 0) {
+					throw new RuntimeException("Missing = in param " + param);
+				}
+				String key = param.substring(0, i);
+				String value = param.substring(i + 1);
+				parameters.add(new Parameter().withParameterKey(key).withParameterValue(value));
+			}
+			return parameters;
+		}
+		
+		private Collection<Parameter> parseKeepParams(String[] params) {
+			Collection<Parameter> parameters = new ArrayList<>();
+			if (params == null) {
+				return parameters;
+			}
+			for (String param : params) {
+				parameters.add(new Parameter().withParameterKey(param).withUsePreviousValue(true));
+			}
+			return parameters;
+		}
+		
+		@Override
+		public void stop(@Nonnull Throwable cause) throws Exception {
+			//
+		}
+		
+		private static final long serialVersionUID = 1L;
+		
+	}
+	
+}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
@@ -120,7 +120,7 @@ public class CFNCreateChangeSetStep extends AbstractCFNCreateSetStep {
 			final String url = this.step.getUrl();
 			CloudFormationStack cfnStack = getCfnStack();
 			cfnStack.createChangeSet(changeSet, readTemplate(file), url, parameters, tags, getStep().getPollInterval(), ChangeSetType.UPDATE, getStep().getRoleArn());
-			return cfnStack.describeOutputs();
+			return null;
 		}
 
 		@Override

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
@@ -27,133 +27,30 @@ import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Tag;
 import com.google.common.base.Preconditions;
 import de.taimos.pipeline.aws.AWSClientFactory;
-import de.taimos.pipeline.aws.cloudformation.parser.JSONParameterFileParser;
-import de.taimos.pipeline.aws.cloudformation.parser.ParameterFileParser;
-import de.taimos.pipeline.aws.cloudformation.parser.YAMLParameterFileParser;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import java.util.ArrayList;
 import java.util.Collection;
 
-public class CFNCreateChangeSetStep extends AbstractStepImpl {
+public class CFNCreateChangeSetStep extends AbstractCFNCreateSetStep {
 
 	private final String changeSet;
-	private final String stack;
-	private String file;
-	private String url;
-	private String[] params;
-	private String[] keepParams;
-	private String[] tags;
-	private String paramsFile;
-	private Long pollInterval = 1000L;
-	private Boolean create = true;
-
-	private String roleArn;
 
 	@DataBoundConstructor
 	public CFNCreateChangeSetStep(String changeSet, String stack) {
+		super(stack);
 		this.changeSet = changeSet;
-		this.stack = stack;
 	}
 
 	public String getChangeSet() {
 		return this.changeSet;
-	}
-
-	public String getStack() {
-		return this.stack;
-	}
-	
-	public String getFile() {
-		return this.file;
-	}
-	
-	@DataBoundSetter
-	public void setFile(String file) {
-		this.file = file;
-	}
-	
-	public String getUrl() {
-		return this.url;
-	}
-	
-	@DataBoundSetter
-	public void setUrl(String url) {
-		this.url = url;
-	}
-	
-	public String[] getParams() {
-		return this.params != null ? this.params.clone() : null;
-	}
-	
-	@DataBoundSetter
-	public void setParams(String[] params) {
-		this.params = params.clone();
-	}
-	
-	public String[] getKeepParams() {
-		return this.keepParams != null ? this.keepParams.clone() : null;
-	}
-	
-	@DataBoundSetter
-	public void setKeepParams(String[] keepParams) {
-		this.keepParams = keepParams.clone();
-	}
-	
-	public String[] getTags() {
-		return this.tags != null ? this.tags.clone() : null;
-	}
-	
-	@DataBoundSetter
-	public void setTags(String[] tags) {
-		this.tags = tags.clone();
-	}
-	
-	public String getParamsFile() {
-		return this.paramsFile;
-	}
-	
-	@DataBoundSetter
-	public void setParamsFile(String paramsFile) {
-		this.paramsFile = paramsFile;
-	}
-
-	public Long getPollInterval() {
-		return this.pollInterval;
-	}
-	
-	@DataBoundSetter
-	public void setPollInterval(Long pollInterval) {
-		this.pollInterval = pollInterval;
-	}
-
-	public Boolean getCreate() {
-		return create;
-	}
-
-	@DataBoundSetter
-	public void setCreate(Boolean create) {
-		this.create = create;
-	}
-
-	public String getRoleArn() {
-		return roleArn;
-	}
-
-	@DataBoundSetter
-	public void setRoleArn(String roleArn) {
-		this.roleArn = roleArn;
 	}
 
 	@Extension
@@ -174,7 +71,7 @@ public class CFNCreateChangeSetStep extends AbstractStepImpl {
 		}
 	}
 	
-	public static class Execution extends AbstractStepExecutionImpl {
+	public static class Execution extends AbstractCFNCreateSetStep.Execution {
 		
 		@Inject
 		private transient CFNCreateChangeSetStep step;
@@ -184,138 +81,59 @@ public class CFNCreateChangeSetStep extends AbstractStepImpl {
 		private transient FilePath workspace;
 		@StepContextParameter
 		private transient TaskListener listener;
-		
+
 		@Override
-		public boolean start() throws Exception {
+		public AbstractCFNCreateSetStep getStep() {
+			return step;
+		}
+
+		@Override
+		public EnvVars getEnvVars() {
+			return envVars;
+		}
+
+		@Override
+		public FilePath getWorkspace() {
+			return workspace;
+		}
+
+		@Override
+		public TaskListener getListener() {
+			return listener;
+		}
+
+		@Override
+		public void checkPreconditions() {
 			final String changeSet = this.step.getChangeSet();
-			final String stack = this.step.getStack();
+			Preconditions.checkArgument(changeSet != null && !changeSet.isEmpty(), "Change Set must not be null or empty");
+		}
+
+		@Override
+		public String getThreadName() {
+			return "cfnCreateChangeSet-" + this.step.getChangeSet();
+		}
+
+		@Override
+		public Object whenStackExists(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception {
+			final String changeSet = this.step.getChangeSet();
 			final String file = this.step.getFile();
 			final String url = this.step.getUrl();
-			final Boolean create = this.step.getCreate();
-			final String roleArn = this.step.getRoleArn();
+			CloudFormationStack cfnStack = getCfnStack();
+			cfnStack.createChangeSet(changeSet, readTemplate(file), url, parameters, tags, getStep().getPollInterval(), ChangeSetType.UPDATE, getStep().getRoleArn());
+			return cfnStack.describeOutputs();
+		}
 
-			final Collection<Parameter> params= this.parseParamsFile(this.step.getParamsFile());
-			params.addAll(this.parseParams(this.step.getParams()));
-			
-			final Collection<Parameter> keepParams = this.parseKeepParams(this.step.getKeepParams());
-			final Collection<Tag> tags = this.parseTags(this.step.getTags());
-
-			Preconditions.checkArgument(changeSet != null && !changeSet.isEmpty(), "Change Set must not be null or empty");
-
-			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
-
-			new Thread("cfnCreateChangeSet-" + changeSet) {
-				@Override
-				public void run() {
-					try {
-						AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, Execution.this.envVars);
-						CloudFormationStack cfnStack = new CloudFormationStack(client, stack, Execution.this.listener);
-						if (cfnStack.exists()) {
-							Execution.this.listener.getLogger().format("Creating CloudFormation change set %s for existing stack %s %n", changeSet, stack);
-							ArrayList<Parameter> parameters = new ArrayList<>(params);
-							parameters.addAll(keepParams);
-							cfnStack.createChangeSet(changeSet, Execution.this.readTemplate(file), url, parameters, tags, Execution.this.step.getPollInterval(), ChangeSetType.UPDATE, roleArn);
-						} else if (create) {
-							Execution.this.listener.getLogger().format("Creating CloudFormation change set %s for new stack %s %n", changeSet, stack);
-							cfnStack.createChangeSet(changeSet, Execution.this.readTemplate(file), url, params, tags, Execution.this.step.getPollInterval(), ChangeSetType.CREATE, roleArn);
-						} else {
-							Execution.this.listener.getLogger().println("No stack found with the name and skipped change set creation due to configuration.");
-						}
-						Execution.this.listener.getLogger().println("Create change set complete");
-						Execution.this.getContext().onSuccess(cfnStack.describeOutputs());
-					} catch (Exception e) {
-						Execution.this.getContext().onFailure(e);
-					}
-				}
-			}.start();
-			return false;
-		}
-		
-		private Collection<Parameter> parseParamsFile(String paramsFile) {
-			try {
-				if (paramsFile == null || paramsFile.isEmpty()) {
-					return new ArrayList<>();
-				}
-				final ParameterFileParser parser;
-				if (paramsFile.endsWith(".json")) {
-					parser = new JSONParameterFileParser();
-				} else
-				if (paramsFile.endsWith(".yaml")) {
-					parser = new YAMLParameterFileParser();
-				} else {
-					throw new RuntimeException("Invalid file extension for parameter file (supports json/yaml)");
-				}
-				return parser.parseParams(this.workspace.child(paramsFile).read());
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-		
-		private String readTemplate(String file) {
-			if (file == null) {
-				return null;
-			}
-			
-			FilePath child = this.workspace.child(file);
-			try {
-				return child.readToString();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-		
-		private Collection<Tag> parseTags(String[] tags) {
-			Collection<Tag> tagList = new ArrayList<>();
-			if (tags == null) {
-				return tagList;
-			}
-			for (String tag : tags) {
-				int i = tag.indexOf("=");
-				if (i < 0) {
-					throw new RuntimeException("Missing = in tag " + tag);
-				}
-				String key = tag.substring(0, i);
-				String value = tag.substring(i + 1);
-				tagList.add(new Tag().withKey(key).withValue(value));
-			}
-			return tagList;
-		}
-		
-		private Collection<Parameter> parseParams(String[] params) {
-			Collection<Parameter> parameters = new ArrayList<>();
-			if (params == null) {
-				return parameters;
-			}
-			for (String param : params) {
-				int i = param.indexOf("=");
-				if (i < 0) {
-					throw new RuntimeException("Missing = in param " + param);
-				}
-				String key = param.substring(0, i);
-				String value = param.substring(i + 1);
-				parameters.add(new Parameter().withParameterKey(key).withParameterValue(value));
-			}
-			return parameters;
-		}
-		
-		private Collection<Parameter> parseKeepParams(String[] params) {
-			Collection<Parameter> parameters = new ArrayList<>();
-			if (params == null) {
-				return parameters;
-			}
-			for (String param : params) {
-				parameters.add(new Parameter().withParameterKey(param).withUsePreviousValue(true));
-			}
-			return parameters;
-		}
-		
 		@Override
-		public void stop(@Nonnull Throwable cause) throws Exception {
-			//
+		public Object whenStackMissing(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception {
+			final String changeSet = this.step.getChangeSet();
+			final String file = this.step.getFile();
+			final String url = this.step.getUrl();
+			getCfnStack().createChangeSet(changeSet, readTemplate(file), url, parameters, tags, getStep().getPollInterval(), ChangeSetType.CREATE, getStep().getRoleArn());
+			return null;
 		}
-		
+
 		private static final long serialVersionUID = 1L;
-		
+
 	}
 	
 }

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
@@ -39,7 +39,7 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.util.Collection;
 
-public class CFNCreateChangeSetStep extends AbstractCFNCreateSetStep {
+public class CFNCreateChangeSetStep extends AbstractCFNCreateStep {
 
 	private final String changeSet;
 
@@ -71,7 +71,7 @@ public class CFNCreateChangeSetStep extends AbstractCFNCreateSetStep {
 		}
 	}
 	
-	public static class Execution extends AbstractCFNCreateSetStep.Execution {
+	public static class Execution extends AbstractCFNCreateStep.Execution {
 		
 		@Inject
 		private transient CFNCreateChangeSetStep step;
@@ -83,7 +83,7 @@ public class CFNCreateChangeSetStep extends AbstractCFNCreateSetStep {
 		private transient TaskListener listener;
 
 		@Override
-		public AbstractCFNCreateSetStep getStep() {
+		public AbstractCFNCreateStep getStep() {
 			return step;
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNExecuteChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNExecuteChangeSetStep.java
@@ -1,0 +1,142 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws.cloudformation;
+
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.ChangeSetType;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.Tag;
+import com.google.common.base.Preconditions;
+import de.taimos.pipeline.aws.AWSClientFactory;
+import de.taimos.pipeline.aws.cloudformation.parser.JSONParameterFileParser;
+import de.taimos.pipeline.aws.cloudformation.parser.ParameterFileParser;
+import de.taimos.pipeline.aws.cloudformation.parser.YAMLParameterFileParser;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CFNExecuteChangeSetStep extends AbstractStepImpl {
+
+	private final String changeSet;
+	private final String stack;
+	private Long pollInterval = 1000L;
+
+	@DataBoundConstructor
+	public CFNExecuteChangeSetStep(String changeSet, String stack) {
+		this.changeSet = changeSet;
+		this.stack = stack;
+	}
+
+	public String getChangeSet() {
+		return this.changeSet;
+	}
+
+	public String getStack() {
+		return this.stack;
+	}
+
+	public Long getPollInterval() {
+		return this.pollInterval;
+	}
+	
+	@DataBoundSetter
+	public void setPollInterval(Long pollInterval) {
+		this.pollInterval = pollInterval;
+	}
+	
+	@Extension
+	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+		
+		public DescriptorImpl() {
+			super(Execution.class);
+		}
+		
+		@Override
+		public String getFunctionName() {
+			return "cfnExecuteChangeSet";
+		}
+		
+		@Override
+		public String getDisplayName() {
+			return "Execute CloudFormation change set";
+		}
+	}
+	
+	public static class Execution extends AbstractStepExecutionImpl {
+		
+		@Inject
+		private transient CFNExecuteChangeSetStep step;
+		@StepContextParameter
+		private transient EnvVars envVars;
+		@StepContextParameter
+		private transient TaskListener listener;
+		
+		@Override
+		public boolean start() throws Exception {
+			final String changeSet = this.step.getChangeSet();
+			final String stack = this.step.getStack();
+
+			Preconditions.checkArgument(changeSet != null && !changeSet.isEmpty(), "Change Set must not be null or empty");
+
+			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
+
+			this.listener.getLogger().format("Executing CloudFormation change set %s %n", changeSet);
+			
+			new Thread("cfnExecuteChangeSet-" + changeSet) {
+				@Override
+				public void run() {
+					try {
+						AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, Execution.this.envVars);
+						CloudFormationStack cfnStack = new CloudFormationStack(client, stack, Execution.this.listener);
+						cfnStack.executeChangeSet(changeSet, Execution.this.step.getPollInterval());
+						Execution.this.listener.getLogger().println("Execute change set complete");
+						Execution.this.getContext().onSuccess(cfnStack.describeOutputs());
+					} catch (Exception e) {
+						Execution.this.getContext().onFailure(e);
+					}
+				}
+			}.start();
+			return false;
+		}
+		
+		@Override
+		public void stop(@Nonnull Throwable cause) throws Exception {
+			//
+		}
+		
+		private static final long serialVersionUID = 1L;
+		
+	}
+	
+}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNExecuteChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNExecuteChangeSetStep.java
@@ -22,17 +22,10 @@
 package de.taimos.pipeline.aws.cloudformation;
 
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
-import com.amazonaws.services.cloudformation.model.ChangeSetType;
-import com.amazonaws.services.cloudformation.model.Parameter;
-import com.amazonaws.services.cloudformation.model.Tag;
 import com.google.common.base.Preconditions;
 import de.taimos.pipeline.aws.AWSClientFactory;
-import de.taimos.pipeline.aws.cloudformation.parser.JSONParameterFileParser;
-import de.taimos.pipeline.aws.cloudformation.parser.ParameterFileParser;
-import de.taimos.pipeline.aws.cloudformation.parser.YAMLParameterFileParser;
 import hudson.EnvVars;
 import hudson.Extension;
-import hudson.FilePath;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
@@ -43,8 +36,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.Collection;
 
 public class CFNExecuteChangeSetStep extends AbstractStepImpl {
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
@@ -35,7 +35,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import javax.inject.Inject;
 import java.util.Collection;
 
-public class CFNUpdateStep extends AbstractCFNCreateSetStep {
+public class CFNUpdateStep extends AbstractCFNCreateStep {
 	
 	private Integer timeoutInMinutes;
 
@@ -71,7 +71,7 @@ public class CFNUpdateStep extends AbstractCFNCreateSetStep {
 		}
 	}
 
-	public static class Execution extends AbstractCFNCreateSetStep.Execution {
+	public static class Execution extends AbstractCFNCreateStep.Execution {
 		
 		@Inject
 		private transient CFNUpdateStep step;
@@ -83,7 +83,7 @@ public class CFNUpdateStep extends AbstractCFNCreateSetStep {
 		private transient TaskListener listener;
 
 		@Override
-		public AbstractCFNCreateSetStep getStep() {
+		public AbstractCFNCreateStep getStep() {
 			return step;
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
@@ -84,22 +84,22 @@ public class CFNUpdateStep extends AbstractCFNCreateStep {
 
 		@Override
 		public AbstractCFNCreateStep getStep() {
-			return step;
+			return this.step;
 		}
 
 		@Override
 		public EnvVars getEnvVars() {
-			return envVars;
+			return this.envVars;
 		}
 
 		@Override
 		public FilePath getWorkspace() {
-			return workspace;
+			return this.workspace;
 		}
 
 		@Override
 		public TaskListener getListener() {
-			return listener;
+			return this.listener;
 		}
 
 		@Override
@@ -112,19 +112,19 @@ public class CFNUpdateStep extends AbstractCFNCreateStep {
 
 		@Override
 		public Object whenStackExists(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception {
-			final String file = getStep().getFile();
-			final String url = getStep().getUrl();
-			CloudFormationStack cfnStack = getCfnStack();
-			cfnStack.update(Execution.this.readTemplate(file), url, parameters, tags, getStep().getPollInterval(), getStep().getRoleArn());
+			final String file = this.getStep().getFile();
+			final String url = this.getStep().getUrl();
+			CloudFormationStack cfnStack = this.getCfnStack();
+			cfnStack.update(this.readTemplate(file), url, parameters, tags, this.getStep().getPollInterval(), this.getStep().getRoleArn());
 			return cfnStack.describeOutputs();
 		}
 
 		@Override
 		public Object whenStackMissing(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception {
-			final String file = getStep().getFile();
-			final String url = getStep().getUrl();
-			CloudFormationStack cfnStack = getCfnStack();
-			cfnStack.create(Execution.this.readTemplate(file), url, parameters, tags, this.step.getTimeoutInMinutes(), getStep().getPollInterval(), getStep().getRoleArn());
+			final String file = this.getStep().getFile();
+			final String url = this.getStep().getUrl();
+			CloudFormationStack cfnStack = this.getCfnStack();
+			cfnStack.create(this.readTemplate(file), url, parameters, tags, this.step.getTimeoutInMinutes(), this.getStep().getPollInterval(), this.getStep().getRoleArn());
 			return cfnStack.describeOutputs();
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
@@ -21,112 +21,29 @@
 
 package de.taimos.pipeline.aws.cloudformation;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
-
-import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepExecutionImpl;
-import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
-import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-
-import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
 import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Tag;
-import com.google.common.base.Preconditions;
-
-import de.taimos.pipeline.aws.AWSClientFactory;
-import de.taimos.pipeline.aws.cloudformation.parser.JSONParameterFileParser;
-import de.taimos.pipeline.aws.cloudformation.parser.ParameterFileParser;
-import de.taimos.pipeline.aws.cloudformation.parser.YAMLParameterFileParser;
-import de.taimos.pipeline.aws.utils.IamRoleUtils;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
-public class CFNUpdateStep extends AbstractStepImpl {
+import javax.inject.Inject;
+import java.util.Collection;
+
+public class CFNUpdateStep extends AbstractCFNCreateSetStep {
 	
-	private final String stack;
-	private String file;
-	private String url;
-	private String[] params;
-	private String[] keepParams;
-	private String[] tags;
-	private String paramsFile;
 	private Integer timeoutInMinutes;
-	private Long pollInterval = 1000L;
-	private Boolean create = true;
-	
-	private String roleArn;
-	
+
 	@DataBoundConstructor
 	public CFNUpdateStep(String stack) {
-		this.stack = stack;
+		super(stack);
 	}
-	
-	public String getStack() {
-		return this.stack;
-	}
-	
-	public String getFile() {
-		return this.file;
-	}
-	
-	@DataBoundSetter
-	public void setFile(String file) {
-		this.file = file;
-	}
-	
-	public String getUrl() {
-		return this.url;
-	}
-	
-	@DataBoundSetter
-	public void setUrl(String url) {
-		this.url = url;
-	}
-	
-	public String[] getParams() {
-		return this.params != null ? this.params.clone() : null;
-	}
-	
-	@DataBoundSetter
-	public void setParams(String[] params) {
-		this.params = params.clone();
-	}
-	
-	public String[] getKeepParams() {
-		return this.keepParams != null ? this.keepParams.clone() : null;
-	}
-	
-	@DataBoundSetter
-	public void setKeepParams(String[] keepParams) {
-		this.keepParams = keepParams.clone();
-	}
-	
-	public String[] getTags() {
-		return this.tags != null ? this.tags.clone() : null;
-	}
-	
-	@DataBoundSetter
-	public void setTags(String[] tags) {
-		this.tags = tags.clone();
-	}
-	
-	public String getParamsFile() {
-		return this.paramsFile;
-	}
-	
-	@DataBoundSetter
-	public void setParamsFile(String paramsFile) {
-		this.paramsFile = paramsFile;
-	}
-	
+
 	public Integer getTimeoutInMinutes() {
 		return this.timeoutInMinutes;
 	}
@@ -135,34 +52,7 @@ public class CFNUpdateStep extends AbstractStepImpl {
 	public void setTimeoutInMinutes(Integer timeoutInMinutes) {
 		this.timeoutInMinutes = timeoutInMinutes;
 	}
-	
-	public Long getPollInterval() {
-		return this.pollInterval;
-	}
-	
-	@DataBoundSetter
-	public void setPollInterval(Long pollInterval) {
-		this.pollInterval = pollInterval;
-	}
-	
-	public Boolean getCreate() {
-		return create;
-	}
-	
-	@DataBoundSetter
-	public void setCreate(Boolean create) {
-		this.create = create;
-	}
-	
-	public String getRoleArn() {
-		return roleArn;
-	}
-	
-	@DataBoundSetter
-	public void setRoleArn(String roleArn) {
-		this.roleArn = roleArn;
-	}
-	
+
 	@Extension
 	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 		
@@ -180,8 +70,8 @@ public class CFNUpdateStep extends AbstractStepImpl {
 			return "Create or Update CloudFormation stack";
 		}
 	}
-	
-	public static class Execution extends AbstractStepExecutionImpl {
+
+	public static class Execution extends AbstractCFNCreateSetStep.Execution {
 		
 		@Inject
 		private transient CFNUpdateStep step;
@@ -191,135 +81,55 @@ public class CFNUpdateStep extends AbstractStepImpl {
 		private transient FilePath workspace;
 		@StepContextParameter
 		private transient TaskListener listener;
-		
+
 		@Override
-		public boolean start() throws Exception {
-			final String stack = this.step.getStack();
-			final String file = this.step.getFile();
-			final String url = this.step.getUrl();
-			final String roleArn = this.step.getRoleArn();
-			final Boolean create = this.step.getCreate();
-			
-			final Collection<Parameter> params = this.parseParamsFile(this.step.getParamsFile());
-			params.addAll(this.parseParams(this.step.getParams()));
-			
-			final Collection<Parameter> keepParams = this.parseKeepParams(this.step.getKeepParams());
-			final Collection<Tag> tags = this.parseTags(this.step.getTags());
-			final Integer timeoutInMinutes = this.step.getTimeoutInMinutes();
-			
-			Preconditions.checkArgument(stack != null && !stack.isEmpty(), "Stack must not be null or empty");
-			Preconditions.checkArgument(roleArn == null || IamRoleUtils.validRoleArn(roleArn), "RoleArn must be a valid ARN.");
-			this.listener.getLogger().format("Updating/Creating CloudFormation stack %s %n", stack);
-			
-			new Thread("cfnUpdate-" + stack) {
-				@Override
-				public void run() {
-					try {
-						AmazonCloudFormationClient client = AWSClientFactory.create(AmazonCloudFormationClient.class, Execution.this.envVars);
-						CloudFormationStack cfnStack = new CloudFormationStack(client, stack, Execution.this.listener);
-						if (cfnStack.exists()) {
-							ArrayList<Parameter> parameters = new ArrayList<>(params);
-							parameters.addAll(keepParams);
-							cfnStack.update(Execution.this.readTemplate(file), url, parameters, tags, Execution.this.step.getPollInterval(), roleArn);
-						} else if (create) {
-							cfnStack.create(Execution.this.readTemplate(file), url, params, tags, timeoutInMinutes, Execution.this.step.getPollInterval(), roleArn);
-						} else {
-							Execution.this.listener.getLogger().println("No stack found with the name and skipped creation due to configuration.");
-						}
-						Execution.this.listener.getLogger().println("Stack update complete");
-						Execution.this.getContext().onSuccess(cfnStack.describeOutputs());
-					} catch (Exception e) {
-						Execution.this.getContext().onFailure(e);
-					}
-				}
-			}.start();
-			return false;
+		public AbstractCFNCreateSetStep getStep() {
+			return step;
 		}
-		
-		private Collection<Parameter> parseParamsFile(String paramsFile) {
-			try {
-				if (paramsFile == null || paramsFile.isEmpty()) {
-					return new ArrayList<>();
-				}
-				final ParameterFileParser parser;
-				if (paramsFile.endsWith(".json")) {
-					parser = new JSONParameterFileParser();
-				} else if (paramsFile.endsWith(".yaml")) {
-					parser = new YAMLParameterFileParser();
-				} else {
-					throw new RuntimeException("Invalid file extension for parameter file (supports json/yaml)");
-				}
-				return parser.parseParams(this.workspace.child(paramsFile).read());
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-		
-		private String readTemplate(String file) {
-			if (file == null) {
-				return null;
-			}
-			
-			FilePath child = this.workspace.child(file);
-			try {
-				return child.readToString();
-			} catch (Exception e) {
-				throw new RuntimeException(e);
-			}
-		}
-		
-		private Collection<Tag> parseTags(String[] tags) {
-			Collection<Tag> tagList = new ArrayList<>();
-			if (tags == null) {
-				return tagList;
-			}
-			for (String tag : tags) {
-				int i = tag.indexOf("=");
-				if (i < 0) {
-					throw new RuntimeException("Missing = in tag " + tag);
-				}
-				String key = tag.substring(0, i);
-				String value = tag.substring(i + 1);
-				tagList.add(new Tag().withKey(key).withValue(value));
-			}
-			return tagList;
-		}
-		
-		private Collection<Parameter> parseParams(String[] params) {
-			Collection<Parameter> parameters = new ArrayList<>();
-			if (params == null) {
-				return parameters;
-			}
-			for (String param : params) {
-				int i = param.indexOf("=");
-				if (i < 0) {
-					throw new RuntimeException("Missing = in param " + param);
-				}
-				String key = param.substring(0, i);
-				String value = param.substring(i + 1);
-				parameters.add(new Parameter().withParameterKey(key).withParameterValue(value));
-			}
-			return parameters;
-		}
-		
-		private Collection<Parameter> parseKeepParams(String[] params) {
-			Collection<Parameter> parameters = new ArrayList<>();
-			if (params == null) {
-				return parameters;
-			}
-			for (String param : params) {
-				parameters.add(new Parameter().withParameterKey(param).withUsePreviousValue(true));
-			}
-			return parameters;
-		}
-		
+
 		@Override
-		public void stop(@Nonnull Throwable cause) throws Exception {
-			//
+		public EnvVars getEnvVars() {
+			return envVars;
 		}
-		
+
+		@Override
+		public FilePath getWorkspace() {
+			return workspace;
+		}
+
+		@Override
+		public TaskListener getListener() {
+			return listener;
+		}
+
+		@Override
+		public void checkPreconditions() {}
+
+		@Override
+		public String getThreadName() {
+			return "cfnUpdate-" + this.step.getStack();
+		}
+
+		@Override
+		public Object whenStackExists(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception {
+			final String file = getStep().getFile();
+			final String url = getStep().getUrl();
+			CloudFormationStack cfnStack = getCfnStack();
+			cfnStack.update(Execution.this.readTemplate(file), url, parameters, tags, getStep().getPollInterval(), getStep().getRoleArn());
+			return cfnStack.describeOutputs();
+		}
+
+		@Override
+		public Object whenStackMissing(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception {
+			final String file = getStep().getFile();
+			final String url = getStep().getUrl();
+			CloudFormationStack cfnStack = getCfnStack();
+			cfnStack.create(Execution.this.readTemplate(file), url, parameters, tags, this.step.getTimeoutInMinutes(), getStep().getPollInterval(), getStep().getRoleArn());
+			return cfnStack.describeOutputs();
+		}
+
 		private static final long serialVersionUID = 1L;
-		
+
 	}
 	
 }

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -27,8 +27,24 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
-import com.amazonaws.services.cloudformation.model.*;
 
+import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
+import com.amazonaws.services.cloudformation.model.Capability;
+import com.amazonaws.services.cloudformation.model.ChangeSetType;
+import com.amazonaws.services.cloudformation.model.CreateChangeSetRequest;
+import com.amazonaws.services.cloudformation.model.CreateStackRequest;
+import com.amazonaws.services.cloudformation.model.DeleteChangeSetRequest;
+import com.amazonaws.services.cloudformation.model.DeleteStackRequest;
+import com.amazonaws.services.cloudformation.model.DescribeChangeSetRequest;
+import com.amazonaws.services.cloudformation.model.DescribeChangeSetResult;
+import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
+import com.amazonaws.services.cloudformation.model.ExecuteChangeSetRequest;
+import com.amazonaws.services.cloudformation.model.Output;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.Stack;
+import com.amazonaws.services.cloudformation.model.Tag;
+import com.amazonaws.services.cloudformation.model.UpdateStackRequest;
 import com.amazonaws.waiters.WaiterUnrecoverableException;
 import hudson.model.TaskListener;
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -21,13 +21,7 @@
 
 package de.taimos.pipeline.aws.cloudformation;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
-
 import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
 import com.amazonaws.services.cloudformation.model.Capability;
 import com.amazonaws.services.cloudformation.model.ChangeSetType;
@@ -45,8 +39,12 @@ import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Stack;
 import com.amazonaws.services.cloudformation.model.Tag;
 import com.amazonaws.services.cloudformation.model.UpdateStackRequest;
-import com.amazonaws.waiters.WaiterUnrecoverableException;
 import hudson.model.TaskListener;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public class CloudFormationStack {
 	

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
@@ -28,7 +28,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import com.amazonaws.services.cloudformation.model.*;
+import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
+import com.amazonaws.services.cloudformation.model.DescribeChangeSetRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsResult;
+import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.amazonaws.services.cloudformation.model.StackEvent;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.concurrent.BasicFuture;
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
@@ -28,16 +28,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+import com.amazonaws.services.cloudformation.model.*;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.concurrent.BasicFuture;
 
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
-import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
-import com.amazonaws.services.cloudformation.model.DescribeStackEventsRequest;
-import com.amazonaws.services.cloudformation.model.DescribeStackEventsResult;
-import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
-import com.amazonaws.services.cloudformation.model.StackEvent;
 import com.amazonaws.waiters.Waiter;
 import com.amazonaws.waiters.WaiterHandler;
 import com.amazonaws.waiters.WaiterParameters;
@@ -53,10 +49,28 @@ public class EventPrinter {
 		this.client = client;
 		this.listener = listener;
 	}
-	
+
+	public void waitAndPrintChangeSetEvents(String stack, String changeSet, Waiter<DescribeChangeSetRequest> waiter, long pollIntervalMillis) throws ExecutionException {
+
+		final BasicFuture<AmazonWebServiceRequest> waitResult = new BasicFuture<>(null);
+
+		waiter.runAsync(new WaiterParameters<>(new DescribeChangeSetRequest().withStackName(stack).withChangeSetName(changeSet)), new WaiterHandler() {
+			@Override
+			public void onWaitSuccess(AmazonWebServiceRequest request) {
+				waitResult.completed(request);
+			}
+
+			@Override
+			public void onWaitFailure(Exception e) {
+				waitResult.failed(e);
+			}
+		});
+
+		waitAndPrintEvents(stack, pollIntervalMillis, waitResult);
+	}
+
 	public void waitAndPrintStackEvents(String stack, Waiter<DescribeStacksRequest> waiter, long pollIntervalMillis) throws ExecutionException {
-		Date startDate = new Date();
-		
+
 		final BasicFuture<AmazonWebServiceRequest> waitResult = new BasicFuture<>(null);
 		
 		waiter.runAsync(new WaiterParameters<>(new DescribeStacksRequest().withStackName(stack)), new WaiterHandler() {
@@ -70,14 +84,20 @@ public class EventPrinter {
 				waitResult.failed(e);
 			}
 		});
-		
+
+		waitAndPrintEvents(stack, pollIntervalMillis, waitResult);
+	}
+
+	private void waitAndPrintEvents(String stack, long pollIntervalMillis, BasicFuture<AmazonWebServiceRequest> waitResult) throws ExecutionException {
+		Date startDate = new Date();
+
 		String lastEventId = null;
 		this.printLine();
 		this.printStackName(stack);
 		this.printLine();
-		
+
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-		
+
 		if (pollIntervalMillis > 0) {
 			while (!waitResult.isDone()) {
 				try {
@@ -107,14 +127,14 @@ public class EventPrinter {
 				}
 			}
 		}
-		
+
 		try {
 			waitResult.get();
 		} catch (InterruptedException e) {
 			this.listener.getLogger().format("Failed to wait for CFN action to complete: %s", e.getMessage());
 		}
 	}
-	
+
 	private void printEvent(SimpleDateFormat sdf, StackEvent event) {
 		String time = this.padRight(sdf.format(event.getTimestamp()), 25);
 		String logicalResourceId = this.padRight(event.getLogicalResourceId(), 20);


### PR DESCRIPTION
Added one step that allows the creation of change sets, and another to execute them later.

Just like the update step, these steps allow stacks to be created or updated. However, the actual create or update actions will deferred until the change set is executed, allowing the changes to be reviewed first.

One special aspect of this implementation is how empty change sets are handled. The ClouldFormation API will create a change set even if there are no changes to apply. However, its status will be 'FAILED', and it will not be possible to execute it. The steps are implemented in such a way that it seems possible to create and execute empty change sets (executing them simply deletes them).
This behavior is what will be generally desired when creating pipelines, because it avoids the need for additional condition checks (i.e. change sets can always be executed).

P.S.: I'm still doing additional tests, but I assume I will be getting some feedback and questions anyway :).