### PR TITLE
Decode job name HTML encoding in RoleSessionNameBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,12 +449,13 @@ String result = invokeLambda(
 # Changelog
 
 ## current master
+* Fix: RoleSessionName (decoding job name HTML url encoding) in `withAWS` step for assume role.  
 
 ## 1.18
 * Fixed regression added by #27 (#JENKINS-47912)
 
 ## 1.17 (*use > 1.18!!*)
-* Add policy for withAWS support - allows an additional policy to be combined with the policy associated with the assumed role. 
+* Add policy for withAWS support - allows an additional policy to be combined with the policy associated with the assumed role.
 * Add `cfnCreateChangeSet` step
 * Add `cfnExecuteChangeSet` step
 * Add endpoint-url for withAWS support - allows configuring a non-AWS endpoint for internally-hosted clouds.
@@ -464,7 +465,7 @@ String result = invokeLambda(
 * Fix: return value of `invokeLambda` is now serializable
 
 ## 1.16
-* Add federatedUserId for withAWS support - generates temporary aws credentials for federated user which gets logged in CloudTrail 
+* Add federatedUserId for withAWS support - generates temporary aws credentials for federated user which gets logged in CloudTrail
 * Add return value to `awsIdentity` step
 * Add `ecrLogin` step
 * Add `invokeLambda` step
@@ -480,7 +481,7 @@ String result = invokeLambda(
 * Fix: Rendering the paths for S3* steps manually (Windows)
 * fixes JENKINS-46247: Fix credentials scope in withAWS step and add a credentials dropdown
 * add `safeName` to `listAWSAccounts` step
- 
+
 ## 1.13
 * Add `s3FindFiles` step
 * add `updateIdP` step

--- a/src/main/java/de/taimos/pipeline/aws/RoleSessionNameBuilder.java
+++ b/src/main/java/de/taimos/pipeline/aws/RoleSessionNameBuilder.java
@@ -9,9 +9,9 @@ package de.taimos.pipeline.aws;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,8 @@ package de.taimos.pipeline.aws;
  */
 
 import com.google.common.base.Joiner;
+import java.net.URLDecoder;
+import java.io.UnsupportedEncodingException;
 
 final class RoleSessionNameBuilder {
 	private static final int ROLE_SESSION_NAME_MAX_LENGTH = 64;
@@ -28,17 +30,23 @@ final class RoleSessionNameBuilder {
 	private static final int NUMBER_OF_SEPARATORS = 2;
 	private final String jobName;
 	private String buildNumber;
-	
+
 	private RoleSessionNameBuilder(String jobName) {
 		this.jobName = jobName;
 	}
-	
+
 	String build() {
-		final String jobNameWithoutWhitespaces = this.jobName.replace(" ", "");
+		String jobNameWithoutEncoding = "";
+		try {
+			jobNameWithoutEncoding = java.net.URLDecoder.decode(this.jobName, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			// UTF-8 is always supported
+		}
+		final String jobNameWithoutWhitespaces = jobNameWithoutEncoding.replace(" ", "");
 		final String jobNameWithoutSlashes = jobNameWithoutWhitespaces.replace("/", "-");
-		
+
 		final int maxJobNameLength = ROLE_SESSION_NAME_MAX_LENGTH - (SESSION_NAME_PREFIX.length() + this.buildNumber.length() + NUMBER_OF_SEPARATORS);
-		
+
 		final int jobNameLength = jobNameWithoutSlashes.length();
 		String finalJobName = jobNameWithoutSlashes;
 		if (jobNameLength > maxJobNameLength) {
@@ -46,14 +54,13 @@ final class RoleSessionNameBuilder {
 		}
 		return Joiner.on("-").join(SESSION_NAME_PREFIX, finalJobName, this.buildNumber);
 	}
-	
+
 	static RoleSessionNameBuilder withJobName(final String jobName) {
 		return new RoleSessionNameBuilder(jobName);
 	}
-	
+
 	RoleSessionNameBuilder withBuildNumber(final String buildNumber) {
 		this.buildNumber = buildNumber;
 		return this;
 	}
 }
-

--- a/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
@@ -57,4 +57,14 @@ public class RoleSessionNameBuilderTest {
 		assertEquals("The result should be equal to the limit", 64, result.length());
 	}
 
+	@Test
+	public void htmlEncodingJobName() throws Exception {
+		String jobName = "withHTMLEncoding%2FJobName";
+		String buildNumber = "123";
+		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder
+				.withJobName(jobName)
+				.withBuildNumber(buildNumber);
+		final String result = roleSessionNameBuilder.build();
+		assertEquals("The result should not have any encoded html characters", "Jenkins-withHTMLEncoding-JobName-123", result);
+	}
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

If job name contains any html encoding characters (eg., feature%2FName), the RoleSessionNameBuilder will not replace it. Then if step like "withAWS" is used to assume role, AWSSecurityTokenServiceException is raised for error in roleSessionName because it contains "%". This behaviour happens if the multi-branch pipeline are used; if the branch name has "/", the corresponding job name will be replaced by "%2F". 


* **What is the new behavior (if this is a feature change)?**
the job name will be decoded before replacing any spaces or slashes.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no breaking change



* **Other information**: