### PR TITLE
Feature/failed stack options

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ In a case where CloudFormation needs to use a different IAM Role for creating th
 def outputs = cfnUpdate(stack:'my-stack', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', roleArn: 'arn:aws:iam::123456789012:role/S3Access')
 ```
 
+It's possible to override the default behaviour of ROLLBACK a stack when the creation fails by using "onFailure". Allowed values are DO_NOTHING, ROLLBACK, or DELETE
+```
+def outputs = cfnUpdate(stack:'my-stack', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', onFailure:'DELETE')
+```
+
 Note: When creating a stack, either `file` or `url` are required. When updating it, omitting both parameters will keep the stack's current template.
 
 ## cfnDelete
@@ -449,7 +454,8 @@ String result = invokeLambda(
 # Changelog
 
 ## current master
-* Fix: RoleSessionName (decoding job name HTML url encoding) in `withAWS` step for assume role.  
+* Fix: RoleSessionName (decoding job name HTML url encoding) in `withAWS` step for assume role.
+* Add `onFailure` option when creating a stack to allow changed behaviour.
 
 ## 1.18
 * Fixed regression added by #27 (#JENKINS-47912)

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
@@ -32,6 +32,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClientBuilder;
+import com.amazonaws.services.cloudformation.model.OnFailure;
 import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Tag;
 import com.google.common.base.Preconditions;
@@ -57,6 +58,7 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 	private Long pollInterval = 1000L;
 	private Boolean create = true;
 	private String roleArn;
+	private String onFailure = OnFailure.ROLLBACK.toString();
 	
 	public AbstractCFNCreateStep(String stack) {
 		this.stack = stack;
@@ -145,6 +147,15 @@ abstract class AbstractCFNCreateStep extends AbstractStepImpl {
 	@DataBoundSetter
 	public void setRoleArn(String roleArn) {
 		this.roleArn = roleArn;
+	}
+
+	public String getOnFailure() {
+		return this.onFailure;
+	}
+
+	@DataBoundSetter
+	public void setOnFailure(String onFailure) {
+		this.onFailure = onFailure;
 	}
 	
 	abstract static class Execution extends AbstractStepExecutionImpl {

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
@@ -128,7 +128,7 @@ public class CFNUpdateStep extends AbstractCFNCreateStep {
 			final String file = this.getStep().getFile();
 			final String url = this.getStep().getUrl();
 			CloudFormationStack cfnStack = this.getCfnStack();
-			cfnStack.create(this.readTemplate(file), url, parameters, tags, this.step.getTimeoutInMinutes(), this.getStep().getPollInterval(), this.getStep().getRoleArn());
+			cfnStack.create(this.readTemplate(file), url, parameters, tags, this.step.getTimeoutInMinutes(), this.getStep().getPollInterval(), this.getStep().getRoleArn(),this.getStep().getOnFailure());
 			return cfnStack.describeOutputs();
 		}
 		

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -39,6 +39,7 @@ import com.amazonaws.services.cloudformation.model.DescribeChangeSetResult;
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
 import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
 import com.amazonaws.services.cloudformation.model.ExecuteChangeSetRequest;
+import com.amazonaws.services.cloudformation.model.OnFailure;
 import com.amazonaws.services.cloudformation.model.Output;
 import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Stack;
@@ -100,14 +101,14 @@ public class CloudFormationStack {
 		return map;
 	}
 	
-	public void create(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, Integer timeoutInMinutes, long pollIntervallMillis, String roleArn) throws ExecutionException {
+	public void create(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, Integer timeoutInMinutes, long pollIntervallMillis, String roleArn, String onFailure) throws ExecutionException {
 		if ((templateBody == null || templateBody.isEmpty()) && (templateUrl == null || templateUrl.isEmpty())) {
 			throw new IllegalArgumentException("Either a file or url for the template must be specified");
 		}
 		
 		CreateStackRequest req = new CreateStackRequest();
 		req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM);
-		req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags).withTimeoutInMinutes(timeoutInMinutes).withRoleARN(roleArn);
+		req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags).withTimeoutInMinutes(timeoutInMinutes).withRoleARN(roleArn).withOnFailure(OnFailure.valueOf(onFailure));
 		this.client.createStack(req);
 		
 		new EventPrinter(this.client, this.listener).waitAndPrintStackEvents(this.stack, this.client.waiters().stackCreateComplete(), pollIntervallMillis);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add onFailure to createstack. This allows to override behavior from the default "ROLLBACK" to DO_NOTHING or DELETE as explained in the aws sdk documentation http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/cloudformation/model/CreateStackRequest.html#withOnFailure-com.amazonaws.services.cloudformation.model.OnFailure-


* **What is the current behavior?** (You can also link to an open issue here)
Default is applied: ROLLBACK


* **What is the new behavior (if this is a feature change)?**
ROLLBACK is the default, but now it has an override possibility


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No

* **Other information**: