### PR TITLE
Allow role ARNs containing paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ String result = invokeLambda(
 * Fix: RoleSessionName (decoding job name HTML url encoding) in `withAWS` step for assume role.
 * Add `onFailure` option when creating a stack to allow changed behaviour.
 * Add the possibility to define specific content-type for s3Upload step.
+* Support roleArns with paths
 
 ## 1.18
 * Fixed regression added by #27 (#JENKINS-47912)

--- a/src/main/java/de/taimos/pipeline/aws/utils/IamRoleUtils.java
+++ b/src/main/java/de/taimos/pipeline/aws/utils/IamRoleUtils.java
@@ -28,7 +28,7 @@ public final class IamRoleUtils {
 
 	private static final String AWS_DEFAULT_PARTITION_NAME = "aws";
 	private static final String AWS_CN_PARTITION_NAME = "aws-cn";
-	private static final Pattern IAM_ROLE_PATTERN = Pattern.compile("arn:(aws|aws-cn):iam::[0-9]{12}:role/[\\w+=,.@-]{1,64}");
+	private static final Pattern IAM_ROLE_PATTERN = Pattern.compile("arn:(aws|aws-cn):iam::[0-9]{12}:role/[\\w+=,.@/-]{1,64}");
 
 	public static String selectPartitionName(String region) {
 		if (Regions.CN_NORTH_1.getName().equals(region)) {


### PR DESCRIPTION
IAM roles support a basic form of hierarchy called "path". This patch
enables roles that are not in the root path to be also accepted as valid
ARNs.

* **Please check if the PR fulfills these requirements**
- [X] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Roles which are outside the root path are rejected as "invalid ARNs"


* **What is the new behavior (if this is a feature change)?**
Roles containing a `/` are now accepted


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No.


* **Other information**:
I have very little Java experience, but thought this bug was easy enough to submit a PR instead of an Issue.