### PR TITLE
Role ARNs with paths can be longer than 64 characters

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/utils/IamRoleUtils.java
+++ b/src/main/java/de/taimos/pipeline/aws/utils/IamRoleUtils.java
@@ -28,7 +28,8 @@ public final class IamRoleUtils {
 
 	private static final String AWS_DEFAULT_PARTITION_NAME = "aws";
 	private static final String AWS_CN_PARTITION_NAME = "aws-cn";
-	private static final Pattern IAM_ROLE_PATTERN = Pattern.compile("arn:(aws|aws-cn):iam::[0-9]{12}:role/[\\w+=,.@/-]{1,64}");
+	private static final Pattern IAM_ROLE_PATTERN = Pattern.compile("arn:(aws|aws-cn):iam::[0-9]{12}:role/([\\w+=,.@/-]{1,512}/)?[\\w+=,.@-]{1,64}");
+	// source: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html
 
 	public static String selectPartitionName(String region) {
 		if (Regions.CN_NORTH_1.getName().equals(region)) {


### PR DESCRIPTION
This reverts 907351c8e195aeae2671823515eebf316ea12e01, but keeps the
functionality by matching the path part explicitly

* **Please check if the PR fulfills these requirements**
- [X] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [X] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix, 2nd iteration of https://github.com/jenkinsci/pipeline-aws-plugin/pull/33


* **What is the current behavior?** (You can also link to an open issue here)
Long RoleARNs are not recognized


* **What is the new behavior (if this is a feature change)?**
Lang RoleARNs are recognized


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: