### PR TITLE
Do not fail on empty change set creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ ec2ShareAmi(
 # Changelog
 
 ## current master
+* Do not fail job on empty change set creation
 
 ## 1.23
 * add updateTrustPolicy step (#48)

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetStep.java
@@ -121,6 +121,8 @@ public class CFNCreateChangeSetStep extends AbstractCFNCreateStep {
 			DescribeChangeSetResult result = this.getCfnStack().describeChangeSet(changeSet);
 			if (ChangeSetStatus.CREATE_COMPLETE.name().equals(result.getStatus())) {
 				return result.getChanges();
+			} else if (ChangeSetStatus.FAILED.name().equals(result.getStatus()) && result.getStatusReason().toLowerCase().contains("the submitted information didn't contain changes")) {
+				return result.getChanges();
 			} else {
 				throw new IllegalStateException("Change set did not create successfully. status=" + result.getStatus() + " reason=" + result.getStatusReason());
 			}

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/CFNCreateChangeSetTests.java
@@ -88,6 +88,26 @@ public class CFNCreateChangeSetTests {
 	}
 
 	@Test
+	public void createEmptyChangeSet() throws Exception {
+		WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "cfnTest");
+		Mockito.when(stack.exists()).thenReturn(true);
+		Mockito.when(stack.describeChangeSet("bar"))
+				.thenReturn(new DescribeChangeSetResult()
+						.withStatus(ChangeSetStatus.FAILED)
+						.withStatusReason("The submitted information didn't contain changes. Submit different information to create a change set.")
+				);
+		job.setDefinition(new CpsFlowDefinition(""
+				+ "node {\n"
+				+ "  def changes = cfnCreateChangeSet(stack: 'foo', changeSet: 'bar')\n"
+				+ "  echo \"changesCount=${changes.size()}\"\n"
+				+ "}\n", true)
+		);
+		Run run = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
+		jenkinsRule.assertLogContains("changesCount=0", run);
+
+	}
+
+	@Test
 	public void createChangeSetStackDoesNotExist() throws Exception {
 		WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "cfnTest");
 		Mockito.when(stack.exists()).thenReturn(false);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fixes the failure state if the changeset is empty. This was introduced when checking the failure status. A failure status is used when both the changeset couldn't be created (due to a bad script) and if the template had no changes.


* **What is the current behavior?** (You can also link to an open issue here)
the step hard fails on an empty changeset


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)

no

* **Other information**: