### PR TITLE
return null on non existant stack with cfnDescribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ cfnDelete(stack:'my-stack', pollInterval:1000)
 
 ## cfnDescribe
 
-The step returns the outputs of the stack as map.
+The step returns the outputs of the stack as map. If the stack does not exist, `null` is returned.
 
 ```
 def outputs = cfnDescribe(stack:'my-stack')
@@ -525,6 +525,7 @@ ec2ShareAmi(
 ## current master
 * Do not fail job on empty change set creation
 * Add support for maps with cloudformation parameters.
+* Return null on cfnDescribe if stack does not exist
 
 ## 1.23
 * add updateTrustPolicy step (#48)

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNDescribeStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNDescribeStep.java
@@ -102,7 +102,11 @@ public class CFNDescribeStep extends Step {
 					AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), Execution.this.getContext());
 					CloudFormationStack cfnStack = new CloudFormationStack(client, stack, listener);
 					try {
-						Execution.this.getContext().onSuccess(cfnStack.describeOutputs());
+						if (cfnStack.exists()) {
+							Execution.this.getContext().onSuccess(cfnStack.describeOutputs());
+						} else {
+							Execution.this.getContext().onSuccess(null);
+						}
 					} catch (AmazonCloudFormationException e) {
 						Execution.this.getContext().onFailure(e);
 					}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
handles cfnDescribe for a stack that does not exist


* **What is the current behavior?** (You can also link to an open issue here)
an exception is thrown and the step fails


* **What is the new behavior (if this is a feature change)?**
null is returned


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**:
Returning null is weird imo, but I'm not sure what a more 'jenkins' experience would be. Can we throw a custom exception?