### PR TITLE
Feature/aws credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ withAWS(credentials:'nameOfSystemCredentials') {
 }
 ```
 
+Use Jenkins AWS credentials information (AWS Access Key: AccessKeyId, AWS Secret Key: SecretAccessKey):
+
+```
+withAWS(credentials:'nameOfAwsCredentials') {
+    // do something
+}
+```
+
 Use profile information from `~/.aws/config`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -565,6 +565,8 @@ ec2ShareAmi(
 * add duration to withAWS
 * add sseAlgorithm to s3Upload
 * add messageAttributes in snsPublish
+* add ability to utilize AWS Credentials Plugin
+* add iamMfaToken to withAWS step
 
 ## 1.25
 * Return ValidateTemplate response on cfnValidate

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,9 @@
         <contributor>
             <name>Tyler Southwick</name>
         </contributor>
+        <contributor>
+            <name>Ryan Davis</name>
+        </contributor>
     </contributors>
     <repositories>
         <repository>
@@ -122,7 +125,11 @@
             <artifactId>plain-credentials</artifactId>
             <version>1.4</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>aws-credentials</artifactId>
+            <version>1.19</version>
+        </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message describes your change
- [X] Tests for the changes have been added if possible (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces a new feature so that you can utilize AWS Credentials Plugin.  It gives the ability to access the access key and secret key from the Credentials store.  Also allows you to pass in a Iam MFA token.  Most of that is taken care of by the AWS Credentials Plugin, however if you want to use the Iam MFA Token, you must pass it in with iamMfaToken.


* **What is the current behavior?** (You can also link to an open issue here)
Today only StandardCredentials are supported.


* **What is the new behavior (if this is a feature change)?**
Now it will look for the credentials id in the StandardCredentials as well as the AwsCredentials store and if StandardCredentials returns a null value. it will use the AwsCredentials.  If both are null, it throws the exception that was thrown before.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
This does not, it works with the previous versions as well as the current.


* **Other information**:
This has been brought up in the issues #45 and we currently need this feature for our deployment pipelines.