### PR TITLE
add retries around cfnUpdateStackSet when stack set is currently busy

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ ec2ShareAmi(
 ## current master
 * add rollback configuration to `cfnUpdate`
 * add `enableTerminationProtection` to `cfnUpdate`
+* add retries around cfnUpdateStackSet when stack set is currently busy
 
 ## 1.26
 * add duration to withAWS

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/AbstractCFNCreateStackSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/AbstractCFNCreateStackSetStep.java
@@ -107,7 +107,7 @@ abstract class AbstractCFNCreateStackSetStep extends TemplateStepBase {
 				public void run() {
 					try {
 						AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), Execution.this.getEnvVars());
-						CloudFormationStackSet cfnStackSet = new CloudFormationStackSet(client, stackSet, Execution.this.getListener());
+						CloudFormationStackSet cfnStackSet = new CloudFormationStackSet(client, stackSet, Execution.this.getListener(), SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY);
 						if (cfnStackSet.exists()) {
 							Collection<Parameter> parameters = ParameterParser.parseWithKeepParams(getWorkspace(), getStep());
 							Execution.this.getContext().onSuccess(Execution.this.whenStackSetExists(parameters, getStep().getAwsTags()));
@@ -132,7 +132,7 @@ abstract class AbstractCFNCreateStackSetStep extends TemplateStepBase {
 
 		protected CloudFormationStackSet getCfnStackSet() {
 			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), this.getEnvVars());
-			return new CloudFormationStackSet(client, this.getStackSet(), this.getListener());
+			return new CloudFormationStackSet(client, this.getStackSet(), this.getListener(), SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY);
 		}
 
 		public C getStep() {

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNDeleteStackSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNDeleteStackSetStep.java
@@ -112,7 +112,7 @@ public class CFNDeleteStackSetStep extends Step {
 				public void run() {
 					try {
 						AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), Execution.this.getContext());
-						CloudFormationStackSet cfnStackSet = new CloudFormationStackSet(client, stackSet, listener);
+						CloudFormationStackSet cfnStackSet = new CloudFormationStackSet(client, stackSet, listener, SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY);
 						cfnStackSet.delete();
 						listener.getLogger().println("Stack Set deletion complete");
 						Execution.this.getContext().onSuccess(null);

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/SleepStrategy.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/SleepStrategy.java
@@ -1,0 +1,8 @@
+package de.taimos.pipeline.aws.cloudformation.stacksets;
+
+public interface SleepStrategy {
+
+	long calculateSleepDuration (int attempt);
+
+	SleepStrategy EXPONENTIAL_BACKOFF_STRATEGY = attempt -> (long) Math.max(Math.pow(2, attempt) * 100L, 60000);
+}

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNDeleteStackSetStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNDeleteStackSetStepTest.java
@@ -54,7 +54,12 @@ public class CFNDeleteStackSetStepTest {
 		jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
 
 		PowerMockito.verifyNew(CloudFormationStackSet.class)
-				.withArguments(Mockito.any(AmazonCloudFormation.class), Mockito.eq("foo"), Mockito.any(StepContext.class));
+				.withArguments(
+						Mockito.any(AmazonCloudFormation.class),
+						Mockito.eq("foo"),
+						Mockito.any(StepContext.class),
+						Mockito.eq(SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY)
+				);
 		Mockito.verify(stackSet).delete();
 	}
 }

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStepTest.java
@@ -2,6 +2,7 @@ package de.taimos.pipeline.aws.cloudformation.stacksets;
 
 import com.amazonaws.client.builder.AwsSyncClientBuilder;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.model.OperationInProgressException;
 import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Tag;
 import com.amazonaws.services.cloudformation.model.UpdateStackSetResult;
@@ -64,7 +65,12 @@ public class CFNUpdateStackSetStepTest {
 		jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
 
 		PowerMockito.verifyNew(CloudFormationStackSet.class, Mockito.atLeastOnce())
-				.withArguments(Mockito.any(AmazonCloudFormation.class), Mockito.eq("foo"), Mockito.any(TaskListener.class));
+				.withArguments(
+						Mockito.any(AmazonCloudFormation.class),
+						Mockito.eq("foo"),
+						Mockito.any(TaskListener.class),
+						Mockito.eq(SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY)
+				);
 		Mockito.verify(stackSet).create(Mockito.anyString(), Mockito.anyString(), Mockito.<Parameter>anyCollection(), Mockito.<Tag>anyCollection());
 	}
 
@@ -88,7 +94,12 @@ public class CFNUpdateStackSetStepTest {
 		jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
 
 		PowerMockito.verifyNew(CloudFormationStackSet.class, Mockito.atLeastOnce())
-				.withArguments(Mockito.any(AmazonCloudFormation.class), Mockito.eq("foo"), Mockito.any(TaskListener.class));
+				.withArguments(
+						Mockito.any(AmazonCloudFormation.class),
+						Mockito.eq("foo"),
+						Mockito.any(TaskListener.class),
+						Mockito.eq(SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY)
+				);
 		@SuppressWarnings("unchecked")
 		ArgumentCaptor<List<Parameter>> parameterCapture = (ArgumentCaptor<List<Parameter>>)(Object)ArgumentCaptor.forClass(List.class);
 		Mockito.verify(stackSet).update(Mockito.anyString(), Mockito.anyString(), parameterCapture.capture(), Mockito.<Tag>anyCollection());
@@ -115,8 +126,13 @@ public class CFNUpdateStackSetStepTest {
 		);
 		jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
 
-		PowerMockito.verifyNew(CloudFormationStackSet.class)
-				.withArguments(Mockito.any(AmazonCloudFormation.class), Mockito.eq("foo"), Mockito.any(TaskListener.class));
+		PowerMockito.verifyNew(CloudFormationStackSet.class, Mockito.atLeastOnce())
+				.withArguments(
+						Mockito.any(AmazonCloudFormation.class),
+						Mockito.eq("foo"),
+						Mockito.any(TaskListener.class),
+						Mockito.eq(SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY)
+				);
 		Mockito.verify(stackSet, Mockito.never()).create(Mockito.anyString(), Mockito.anyString(), Mockito.<Parameter>anyCollection(), Mockito.<Tag>anyCollection());
 	}
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature - cfn stack sets can only have one modification at a time. If an operation is currently in progress, this can fail the jenkins step. This change puts some retries around that behavior


* **What is the current behavior?** (You can also link to an open issue here)
The jenkins pipeline will fail if the stack set has a current operation running.


* **What is the new behavior (if this is a feature change)?**
the pipeline will attempt to retry and wait up to 10 times


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: