### PR TITLE
Add custom cloudformation wait polling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ ec2ShareAmi(
 # Changelog
 
 ## current master
+* use custom polling strategy for cloudformation waiters to speed up pipeline feedback from cloudformation changes
 * add support for tagsFile in cfnUpdate, cfnCreateChangeSet, cfnUpdateStackSet
 * add `administratorRoleArn` to cfnUpdateStackSet
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/utils/TimeOutRetryStrategy.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/utils/TimeOutRetryStrategy.java
@@ -1,0 +1,24 @@
+package de.taimos.pipeline.aws.cloudformation.utils;
+
+import com.amazonaws.waiters.PollingStrategy;
+import com.amazonaws.waiters.PollingStrategyContext;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+public class TimeOutRetryStrategy implements PollingStrategy.RetryStrategy {
+
+	private final OffsetDateTime start;
+	private final Duration maxTime;
+
+	public TimeOutRetryStrategy(Duration maxTime) {
+		this.start = OffsetDateTime.now();
+		this.maxTime = maxTime;
+	}
+
+	@Override
+	public boolean shouldRetry(PollingStrategyContext pollingStrategyContext) {
+		Duration difference = Duration.between(start, OffsetDateTime.now());
+		return difference.compareTo(maxTime) < 0;
+	}
+}

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/utils/TimeOutRetryStrategyTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/utils/TimeOutRetryStrategyTests.java
@@ -1,0 +1,38 @@
+package de.taimos.pipeline.aws.cloudformation.utils;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.waiters.PollingStrategyContext;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
+
+public class TimeOutRetryStrategyTests {
+
+	@Test
+	public void retriesLessThanMaxTime() throws InterruptedException {
+		TimeOutRetryStrategy retryStrategy = new TimeOutRetryStrategy(Duration.ofSeconds(1));
+
+		AmazonWebServiceRequest request = Mockito.mock(AmazonWebServiceRequest.class);
+		Assertions.assertThat(retryStrategy.shouldRetry(pollingStrategyContext(request, 5))).isTrue();
+
+		Thread.sleep(1100);
+		Assertions.assertThat(retryStrategy.shouldRetry(pollingStrategyContext(request, 1))).isFalse();
+	}
+
+	/**
+	 * the aws-sdk-java (currently as of 7/12/2018) does not have a publicly available constructor to create a PollingStrategyContext.
+	 */
+	private PollingStrategyContext pollingStrategyContext(AmazonWebServiceRequest request, int retriesAttempted) {
+		try {
+			Constructor<PollingStrategyContext> constructor = PollingStrategyContext.class.getDeclaredConstructor(AmazonWebServiceRequest.class, int.class);
+			constructor.setAccessible(true);
+			return constructor.newInstance(request, retriesAttempted);
+		} catch (NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException e) {
+			throw new IllegalStateException("Could not create a PollingStrategyContext", e);
+		}
+	}
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improves the task responsiveness from the jenkins ui


* **What is the current behavior?** (You can also link to an open issue here)
cloudformation uses the default polling configuration (sleep for 30 seconds)

* **What is the new behavior (if this is a feature change)?**
a custom polling configuration is used to respect the polling duration that is configurable by the step.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: