### PR TITLE
Support setting `Content-Encoding` in the `s3Upload` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ Specific cachecontrol can be added to uploaded files
 s3Upload(bucket:"my-bucket", path:'path/to/targetFolder/', includePathPattern:'**/*.svg', workingDir:'dist', cacheControl:'public,max-age=31536000')
 ```
 
+Specific content encoding can be added to uploaded files
+```
+s3Upload(file:'file.txt', bucket:'my-bucket', contentEncoding: 'gzip')
+```
+
 Specific content type can be added to uploaded files
 
 ```
@@ -614,6 +619,7 @@ ec2ShareAmi(
 # Changelog
 
 ## current master
+* content encoding can be specified in `s3Upload` step
 
 ## 1.29
 * fix issues with stack timeouts


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)

* **What kind of change does this PR introduce?**
Feature: Allow `Content-Encoding` header can be specified in the `s3Upload` step.

* **What is the current behavior?** (You can also link to an open issue here)
We can't set the `Content-Encoding` header with the `s3Upload` step.

* **What is the new behavior (if this is a feature change)?**
We can set the `Content-Encoding` header if we want.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No.

* **Other information**:
N/A