### PR TITLE
handle cloudformation-throttle on stacksets

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,7 @@ ec2ShareAmi(
 * allow the customization of setting a roleSessionName
 * content encoding can be specified in `s3Upload` step
 * allow configuration of cloudformation stack timeout
+* handle throttles from cloudformation stackset operations
 
 ## 1.29
 * fix issues with stack timeouts

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSetTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSetTest.java
@@ -327,6 +327,27 @@ public class CloudFormationStackSetTest {
 		stackSet.waitForOperationToComplete(operationId, Duration.ofMillis(5));
 	}
 
+	@Test
+	public void waitForOperationToCompleteWithThrottle() throws InterruptedException {
+		String operationId = UUID.randomUUID().toString();
+		AmazonCloudFormationException ex = new AmazonCloudFormationException("error");
+		ex.setErrorCode("Throttling");
+		Mockito.when(client.describeStackSetOperation(new DescribeStackSetOperationRequest()
+				.withStackSetName("foo")
+				.withOperationId(operationId)
+		)).thenThrow(ex)
+		.thenReturn(new DescribeStackSetOperationResult()
+				.withStackSetOperation(new StackSetOperation()
+						.withStatus(StackSetOperationStatus.RUNNING)
+				)
+		).thenReturn(new DescribeStackSetOperationResult()
+				.withStackSetOperation(new StackSetOperation()
+						.withStatus(StackSetOperationStatus.SUCCEEDED)
+				)
+		);
+		stackSet.waitForOperationToComplete(operationId, Duration.ofMillis(5));
+	}
+
 	@Test(expected = StackSetOperationFailedException.class)
 	public void waitForOperationToCompleteFailure() throws InterruptedException {
 		String operationId = UUID.randomUUID().toString();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix  - there is no "waiter" for stack set operation status and Throttled requests weren't being handled.


* **What is the current behavior?** (You can also link to an open issue here)
If the API request is throttled, the step fails in jenkins


* **What is the new behavior (if this is a feature change)?**
Applies the sleep strategy (which by default is exponential backoff)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: