### PR TITLE
add support for stack set OperationConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,11 @@ To set a custom administrator role ARN:
   cfnUpdateStackSet(stackSet:'myStackSet', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', administratorRoleArn: 'mycustomarn')
 ```
 
+To set a operation preferences:
+```
+  cfnUpdateStackSet(stackSet:'myStackSet', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', operationPreferences: [failureToleranceCount: 5])
+```
+
 ## cfnDeleteStackSet
 
 Deletes a stack set.
@@ -621,6 +626,7 @@ ec2ShareAmi(
 ## current master
 * add paging for listAWSAccounts (#128)
 * retry stackset update on StaleRequestException
+* add support for OperationPreferences in cfnUpdateStackSet
 
 ## 1.31
 * handle throttles from cloudformation stackset operations

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStep.java
@@ -21,30 +21,40 @@
 
 package de.taimos.pipeline.aws.cloudformation.stacksets;
 
-import java.util.Collection;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
-
 import com.amazonaws.services.cloudformation.model.DescribeStackSetResult;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.StackSetOperationPreferences;
+import com.amazonaws.services.cloudformation.model.StackSetStatus;
+import com.amazonaws.services.cloudformation.model.Tag;
+import com.amazonaws.services.cloudformation.model.UpdateStackSetResult;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
-import com.amazonaws.services.cloudformation.model.Parameter;
-import com.amazonaws.services.cloudformation.model.StackSetStatus;
-import com.amazonaws.services.cloudformation.model.Tag;
-import com.amazonaws.services.cloudformation.model.UpdateStackSetResult;
-
-import de.taimos.pipeline.aws.utils.StepUtils;
-import hudson.Extension;
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Set;
 
 public class CFNUpdateStackSetStep extends AbstractCFNCreateStackSetStep {
 
 	@DataBoundConstructor
 	public CFNUpdateStackSetStep(String stackSet) {
 		super(stackSet);
+	}
+
+	private StackSetOperationPreferences operationPreferences;
+
+	public StackSetOperationPreferences getOperationPreferences() {
+		return operationPreferences;
+	}
+
+	@DataBoundSetter
+	public void setOperationPreferences(JenkinsStackSetOperationPreferences operationPreferences) {
+		this.operationPreferences = operationPreferences;
 	}
 
 	@Extension
@@ -92,7 +102,7 @@ public class CFNUpdateStackSetStep extends AbstractCFNCreateStackSetStep {
 			final String url = this.getStep().getUrl();
 			CloudFormationStackSet cfnStackSet = this.getCfnStackSet();
 			UpdateStackSetResult operation = cfnStackSet.update(this.getStep().readTemplate(this), url, parameters, tags,
-					this.getStep().getAdministratorRoleArn(), this.getStep().getExecutionRoleName());
+					this.getStep().getAdministratorRoleArn(), this.getStep().getExecutionRoleName(), this.getStep().getOperationPreferences());
 			cfnStackSet.waitForOperationToComplete(operation.getOperationId(), getStep().getPollConfiguration().getPollInterval());
 			return cfnStackSet.describe();
 		}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSet.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSet.java
@@ -21,9 +21,6 @@
 
 package de.taimos.pipeline.aws.cloudformation.stacksets;
 
-import java.time.Duration;
-import java.util.Collection;
-
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
 import com.amazonaws.services.cloudformation.model.Capability;
@@ -36,14 +33,17 @@ import com.amazonaws.services.cloudformation.model.DescribeStackSetRequest;
 import com.amazonaws.services.cloudformation.model.DescribeStackSetResult;
 import com.amazonaws.services.cloudformation.model.OperationInProgressException;
 import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.StackSetOperationPreferences;
 import com.amazonaws.services.cloudformation.model.StackSetOperationStatus;
 import com.amazonaws.services.cloudformation.model.StackSetStatus;
 import com.amazonaws.services.cloudformation.model.StaleRequestException;
 import com.amazonaws.services.cloudformation.model.Tag;
 import com.amazonaws.services.cloudformation.model.UpdateStackSetRequest;
 import com.amazonaws.services.cloudformation.model.UpdateStackSetResult;
-
 import hudson.model.TaskListener;
+
+import java.time.Duration;
+import java.util.Collection;
 
 public class CloudFormationStackSet {
 
@@ -95,7 +95,7 @@ public class CloudFormationStackSet {
 		return result;
 	}
 
-	public DescribeStackSetResult waitForStackState(StackSetStatus expectedStatus, Duration pollInterval) throws InterruptedException {
+	DescribeStackSetResult waitForStackState(StackSetStatus expectedStatus, Duration pollInterval) throws InterruptedException {
 		DescribeStackSetResult result = describe();
 		this.listener.getLogger().println("stackSetId=" + result.getStackSet().getStackSetId() + " status=" + result.getStackSet().getStatus());
 		StackSetStatus currentStatus = StackSetStatus.fromValue(result.getStackSet().getStatus());
@@ -127,7 +127,8 @@ public class CloudFormationStackSet {
 		}
 	}
 
-	public UpdateStackSetResult update(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, String administratorRoleArn, String executionRoleName) throws InterruptedException {
+	public UpdateStackSetResult update(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags,
+									String administratorRoleArn, String executionRoleName, StackSetOperationPreferences operationPreferences) throws InterruptedException {
 		this.listener.getLogger().format("Updating CloudFormation stack set %s %n", this.stackSet);
 		UpdateStackSetRequest req = new UpdateStackSetRequest()
 				.withStackSetName(this.stackSet)
@@ -135,6 +136,7 @@ public class CloudFormationStackSet {
 				.withParameters(params)
 				.withAdministrationRoleARN(administratorRoleArn)
 				.withExecutionRoleName(executionRoleName)
+				.withOperationPreferences(operationPreferences)
 				.withTags(tags);
 
 		if (templateBody != null && !templateBody.isEmpty()) {

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/JenkinsStackSetOperationPreferences.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/JenkinsStackSetOperationPreferences.java
@@ -1,0 +1,45 @@
+package de.taimos.pipeline.aws.cloudformation.stacksets;
+
+import com.amazonaws.services.cloudformation.model.StackSetOperationPreferences;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.util.Collection;
+
+public class JenkinsStackSetOperationPreferences extends StackSetOperationPreferences {
+
+	@DataBoundConstructor
+	public JenkinsStackSetOperationPreferences() {
+
+	}
+
+	@DataBoundSetter
+	@Override
+	public void setRegionOrder(Collection<String> regionOrder) {
+		super.setRegionOrder(regionOrder);
+	}
+
+	@DataBoundSetter
+	@Override
+	public void setFailureToleranceCount(Integer failureToleranceCount) {
+		super.setFailureToleranceCount(failureToleranceCount);
+	}
+
+	@DataBoundSetter
+	@Override
+	public void setFailureTolerancePercentage(Integer failureTolerancePercentage) {
+		super.setFailureTolerancePercentage(failureTolerancePercentage);
+	}
+
+	@DataBoundSetter
+	@Override
+	public void setMaxConcurrentCount(Integer maxConcurrentCount) {
+		super.setMaxConcurrentCount(maxConcurrentCount);
+	}
+
+	@DataBoundSetter
+	@Override
+	public void setMaxConcurrentPercentage(Integer maxConcurrentPercentage) {
+		super.setMaxConcurrentPercentage(maxConcurrentPercentage);
+	}
+}

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStackTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStackTests.java
@@ -1,7 +1,11 @@
 package de.taimos.pipeline.aws.cloudformation;
 
-import java.util.Collections;
-
+import com.amazonaws.client.builder.AwsSyncClientBuilder;
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.Tag;
+import de.taimos.pipeline.aws.AWSClientFactory;
+import hudson.EnvVars;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Before;
@@ -15,13 +19,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import com.amazonaws.client.builder.AwsSyncClientBuilder;
-import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.cloudformation.model.Parameter;
-import com.amazonaws.services.cloudformation.model.Tag;
-
-import de.taimos.pipeline.aws.AWSClientFactory;
-import hudson.EnvVars;
+import java.util.Collections;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSetTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSetTest.java
@@ -167,7 +167,7 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update("body", null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null);
+		UpdateStackSetResult result = stackSet.update("body", null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client).updateStackSet(captor.capture());
@@ -193,7 +193,7 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, "url", Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null);
+		UpdateStackSetResult result = stackSet.update(null, "url", Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client).updateStackSet(captor.capture());
@@ -219,7 +219,7 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update("body", null, Collections.singletonList(parameter1), Collections.singletonList(tag1), "bar", "baz");
+		UpdateStackSetResult result = stackSet.update("body", null, Collections.singletonList(parameter1), Collections.singletonList(tag1), "bar", "baz", null);
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client).updateStackSet(captor.capture());
@@ -247,7 +247,7 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null);
+		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client).updateStackSet(captor.capture());
@@ -276,7 +276,8 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null);
+		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1),
+				null, null, null);
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client, Mockito.times(2)).updateStackSet(captor.capture());
@@ -306,7 +307,7 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null);
+		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client, Mockito.times(2)).updateStackSet(captor.capture());


### PR DESCRIPTION
fixes #76

* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)
unable to set stack set operation preferences on cfnUpdateStackSet


* **What is the new behavior (if this is a feature change)?**
allows that property to be set


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: