### PR TITLE
Fixed wrong validation for tags equals to null:

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,8 @@ ec2ShareAmi(
 
 ## current master
 
+* fixed tagsFile parameter being ignored when the tags parameter equals null.
+
 ## 1.32
 * add paging for listAWSAccounts (#128)
 * retry stackset update on StaleRequestException

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/TemplateStepBase.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/TemplateStepBase.java
@@ -157,17 +157,16 @@ public abstract class TemplateStepBase extends Step implements ParameterProvider
 
 	protected final Collection<Tag> getAwsTags(StepExecution stepExecution) {
 		Collection<Tag> tagList = new ArrayList<>();
-		if (this.tags == null) {
-			return tagList;
-		}
-		for (String tag : this.tags) {
-			int i = tag.indexOf('=');
-			if (i < 0) {
-				throw new IllegalArgumentException("Missing = in tag " + tag);
+		if (this.tags != null) {
+			for (String tag : this.tags) {
+				int i = tag.indexOf('=');
+				if (i < 0) {
+					throw new IllegalArgumentException("Missing = in tag " + tag);
+				}
+				String key = tag.substring(0, i);
+				String value = tag.substring(i + 1);
+				tagList.add(new Tag().withKey(key).withValue(value));
 			}
-			String key = tag.substring(0, i);
-			String value = tag.substring(i + 1);
-			tagList.add(new Tag().withKey(key).withValue(value));
 		}
 		if (this.tagsFile != null) {
 			FilePath tagsFile = loadFileFromWorkspace(stepExecution, this.tagsFile);


### PR DESCRIPTION
When using tagsFile parameter only without the tags parameter the
content of the tagsFile was being ignored due to this validation.

This commits ensures that each parameter is validated individually and
we don't need to send both tags = [] and tagsFile= "filename" to work
properly.

* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When setting the tagsFile parameter without specifying the tags the tagsFile parameter is ignored.


* **What is the new behavior (if this is a feature change)?**
The tagsFile parameter does not longer requires to set the tags parameter empty to work.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No


* **Other information**: