### PR TITLE
Look up aws partition from com.amazonaws.regions.RegionUtils

### DIFF
--- a/src/test/java/utils/IamRoleUtilsTest.java
+++ b/src/test/java/utils/IamRoleUtilsTest.java
@@ -21,6 +21,7 @@ package utils;
  */
 
 import org.junit.Test;
+import org.junit.Assert;
 
 import de.taimos.pipeline.aws.utils.IamRoleUtils;
 
@@ -29,13 +30,13 @@ public class IamRoleUtilsTest {
 	@Test
 	public void findPartitionWithRegionName() throws Exception {
 		// example of type 'aws'
-		IamRoleUtils.selectPartitionName("us-east-1");
+		Assert.assertEquals("aws", IamRoleUtils.selectPartitionName("us-east-1"));
 
 		// example of type 'aws-cn'
-		IamRoleUtils.selectPartitionName("cn-north-1");
+		Assert.assertEquals("aws-cn", IamRoleUtils.selectPartitionName("cn-north-1"));
 
 		// example of type 'aws-us-gov'
-		IamRoleUtils.selectPartitionName("us-gov-west-1");
+		Assert.assertEquals("aws-us-gov", IamRoleUtils.selectPartitionName("us-gov-west-1"));
 		// no exception -> ok
 	}
 

--- a/src/test/java/utils/IamRoleUtilsTest.java
+++ b/src/test/java/utils/IamRoleUtilsTest.java
@@ -1,4 +1,4 @@
-package de.taimos.pipeline.aws.utils;
+package utils;
 
 /*-
  * #%L
@@ -20,25 +20,23 @@ package de.taimos.pipeline.aws.utils;
  * #L%
  */
 
-import java.util.regex.Pattern;
+import org.junit.Test;
 
-import com.amazonaws.regions.RegionUtils;
+import de.taimos.pipeline.aws.utils.IamRoleUtils;
 
-public final class IamRoleUtils {
+public class IamRoleUtilsTest {
 
-	private static final Pattern IAM_ROLE_PATTERN = Pattern.compile("arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role/([\\w+=,.@/-]{1,512}/)?[\\w+=,.@-]{1,64}");
-	// source: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html
+	@Test
+	public void findPartitionWithRegionName() throws Exception {
+		// example of type 'aws'
+		IamRoleUtils.selectPartitionName("us-east-1");
 
-	private IamRoleUtils() {
-		// hidden constructor
-	}
+		// example of type 'aws-cn'
+		IamRoleUtils.selectPartitionName("cn-north-1");
 
-	public static String selectPartitionName(String region) {
-		return (RegionUtils.getRegion(region).getPartition());
-	}
-
-	public static boolean validRoleArn(String role) {
-		return (IAM_ROLE_PATTERN.matcher(role).matches());
+		// example of type 'aws-us-gov'
+		IamRoleUtils.selectPartitionName("us-gov-west-1");
+		// no exception -> ok
 	}
 
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Static lookup of partition name based on if statement. Only supports default 'aws' and China regions' 'aws-cn'


* **What is the new behavior (if this is a feature change)?**
Dynamic lookup of partition based on region name using com.amazonaws.regions.RegionUtils helper class. Supports all regions and partitions.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No breaking changes.


* **Other information**: