### PR TITLE
Add jelly descriptions for snippet-generator

### DIFF
--- a/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/config.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Stack}" field="stack">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%Poll Interval in milliseconds}" field="pollInterval">
+        <f:textbox />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/help-pollInterval.html
+++ b/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/help-pollInterval.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+    How often to check the status of the delete operation in milliseconds. 0 will disable event printing.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/help-stack.html
+++ b/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/help-stack.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+    This is the name of the existing Cloudformation template to delete
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep/help.html
@@ -1,0 +1,24 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+    <p>
+        Delete Cloudformation Templates
+    </p>
+</div>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] - Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adding jelly templates so that the snippet-generator works correctly


* **What is the current behavior?** (You can also link to an open issue here)
The cfnDelete step displays `This step has not yet defined any visual configuration` when trying to use the [Snippet Generator](https://jenkins.io/doc/book/pipeline/getting-started/#snippet-generator).


* **What is the new behavior (if this is a feature change)?**
The cfnDelete step will display fields and their descriptions to generate a snippet.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No


* **Other information**:
The PR template mentions a changelog, but I couldn't see one in the files. Does this step need to be done?