### PR TITLE
increase retry count to make builds more resiliant to AWS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,7 @@ ec2ShareAmi(
 # Changelog
 
 ## current master
+* Increase AWS SDK retry count from default (3 retries) to 10 retries
 
 ## 1.35
 * fixing regression that `region` was now mandatory on `withAWS`

--- a/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
@@ -20,6 +20,7 @@
  */
 package de.taimos.pipeline.aws;
 
+import com.amazonaws.retry.RetryPolicy;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
@@ -80,6 +81,8 @@ public class AWSClientFactory {
 
 	private static ClientConfiguration getClientConfiguration(EnvVars vars) {
 		ClientConfiguration clientConfiguration = new ClientConfiguration();
+		//the default max retry is 3. Increasing this to be more resilient to upstream errors
+		clientConfiguration.setRetryPolicy(new RetryPolicy(null, null, 10, false));
 		ProxyConfiguration.configure(vars, clientConfiguration);
 		return clientConfiguration;
 	}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds more retries to AWS SDK API calls


* **What is the current behavior?** (You can also link to an open issue here)
Errors propogate up after 3 failed attempts (including throttles)


* **What is the new behavior (if this is a feature change)?**
API calls will be tried up to 10 times


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**:
I picked 10 as an arbitrary number. Not sure if there are opinions about this. But, with 3 I see a lot of throttle exceptions (esp from cloudformation).