### PR TITLE
Cfn autoexpand capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ ec2ShareAmi(
 
 ## current master
 * Increase AWS SDK retry count from default (3 retries) to 10 retries
+* Add CAPABILITY_NAMED_IAM to Cloudformation Stacks and Stacksets
 
 ## 1.35
 * fixing regression that `region` was now mandatory on `withAWS`

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.341</version>
+            <version>1.11.457</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -113,7 +113,7 @@ public class CloudFormationStack {
 		}
 
 		CreateStackRequest req = new CreateStackRequest();
-		req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM).withEnableTerminationProtection(enableTerminationProtection);
+		req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM, Capability.CAPABILITY_AUTO_EXPAND).withEnableTerminationProtection(enableTerminationProtection);
 		req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags)
 				.withTimeoutInMinutes(pollConfiguration.getTimeout() == null ? null : (int) pollConfiguration.getTimeout().toMinutes())
 				.withRoleARN(roleArn)
@@ -127,7 +127,7 @@ public class CloudFormationStack {
 	public void update(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, PollConfiguration pollConfiguration, String roleArn, RollbackConfiguration rollbackConfig) throws ExecutionException {
 		try {
 			UpdateStackRequest req = new UpdateStackRequest();
-			req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM);
+			req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM, Capability.CAPABILITY_AUTO_EXPAND);
 
 			if (templateBody != null && !templateBody.isEmpty()) {
 				req.setTemplateBody(templateBody);
@@ -160,7 +160,7 @@ public class CloudFormationStack {
 	public void createChangeSet(String changeSetName, String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, PollConfiguration pollConfiguration, ChangeSetType changeSetType, String roleArn, RollbackConfiguration rollbackConfig) throws ExecutionException {
 		try {
 			CreateChangeSetRequest req = new CreateChangeSetRequest();
-			req.withChangeSetName(changeSetName).withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM).withChangeSetType(changeSetType);
+			req.withChangeSetName(changeSetName).withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM, Capability.CAPABILITY_AUTO_EXPAND).withChangeSetType(changeSetType);
 
 			if (ChangeSetType.CREATE.equals(changeSetType)) {
 				this.listener.getLogger().format("Creating CloudFormation change set %s for new stack %s %n", changeSetName, this.stack);

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSet.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSet.java
@@ -83,7 +83,7 @@ public class CloudFormationStackSet {
 		this.listener.getLogger().println("Creating stack set " + this.stackSet);
 		CreateStackSetRequest req = new CreateStackSetRequest()
 				.withStackSetName(this.stackSet)
-				.withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM)
+				.withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM, Capability.CAPABILITY_AUTO_EXPAND)
 				.withTemplateBody(templateBody)
 				.withTemplateURL(templateUrl)
 				.withParameters(params)
@@ -132,7 +132,7 @@ public class CloudFormationStackSet {
 		this.listener.getLogger().format("Updating CloudFormation stack set %s %n", this.stackSet);
 		UpdateStackSetRequest req = new UpdateStackSetRequest()
 				.withStackSetName(this.stackSet)
-				.withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM)
+				.withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM, Capability.CAPABILITY_AUTO_EXPAND)
 				.withParameters(params)
 				.withAdministrationRoleARN(administratorRoleArn)
 				.withExecutionRoleName(executionRoleName)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [na] Tests for the changes have been added if possible (for bug fixes / features)
- [na] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Allowed `CAPABILITY_AUTO_EXPAND ` as in [Capabilities.member.N](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html)


* **What is the current behavior?** (You can also link to an open issue here)
Stacks being updated with template macros display an error on stack create/update:

     `Requires capabilities : [CAPABILITY_AUTO_EXPAND]`


* **What is the new behavior (if this is a feature change)?**
Stacks with template macros can be created


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No business logic has been changed.


* **Other information**: