### PR TITLE
Retain source path with pattern matched files

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -253,6 +253,7 @@ public class S3UploadStep extends AbstractS3Step {
 			final String contentEncoding = this.step.getContentEncoding();
 			final String contentType = this.step.getContentType();
 			final String sseAlgorithm = this.step.getSseAlgorithm();
+			boolean omitSourcePath = false;
 
 			if (this.step.getMetadatas() != null && this.step.getMetadatas().length != 0) {
 				for (String metadata : this.step.getMetadatas()) {
@@ -275,6 +276,7 @@ public class S3UploadStep extends AbstractS3Step {
 			}
 			if (file != null) {
 				children.add(dir.child(file));
+				omitSourcePath = true;
 			} else if (excludePathPattern != null && !excludePathPattern.trim().isEmpty()) {
 				children.addAll(Arrays.asList(dir.list(includePathPattern, excludePathPattern, true)));
 			} else {
@@ -287,7 +289,7 @@ public class S3UploadStep extends AbstractS3Step {
 			if (children.isEmpty()) {
 				listener.getLogger().println("Nothing to upload");
 				return null;
-			} else if (children.size() == 1) {
+			} else if (omitSourcePath) {
 				FilePath child = children.get(0);
 				listener.getLogger().format("Uploading %s to s3://%s/%s %n", child.toURI(), bucket, path);
 				if (!child.exists()) {

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -21,8 +21,11 @@
 
 package de.taimos.pipeline.aws;
 
+import org.assertj.core.api.Assertions;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 
@@ -61,4 +64,34 @@ public class S3UploadStepTest {
 		step.setFile("my-file");
 		Assert.assertEquals("", step.getPath());
 	}
+
+	@Test
+	public void bucketMustBeDefined() throws Exception {
+		S3UploadStep step = new S3UploadStep(null, false, false);
+		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
+		Throwable t = Assertions.catchThrowable(execution::run);
+		Assert.assertTrue(t instanceof IllegalArgumentException);
+		Assert.assertEquals("Bucket must not be null or empty", t.getMessage());
+	}
+
+	@Test
+	public void fileOrIncludePathPatternMustBeDefined() throws Exception {
+		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
+		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
+		Throwable t = Assertions.catchThrowable(execution::run);
+		Assert.assertTrue(t instanceof IllegalArgumentException);
+		Assert.assertEquals("File or IncludePathPattern must not be null", t.getMessage());
+	}
+
+	@Test
+	public void doNotAcceptFileAndIncludePathPatternArguments() throws Exception {
+		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
+		step.setFile("file.txt");
+		step.setIncludePathPattern("*.txt");
+		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
+		Throwable t = Assertions.catchThrowable(execution::run);
+		Assert.assertTrue(t instanceof IllegalArgumentException);
+		Assert.assertEquals("File and IncludePathPattern cannot be use together", t.getMessage());
+	}
+
 }

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTransferManagerIntegrationTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTransferManagerIntegrationTest.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.s3.transfer.ObjectMetadataProvider;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import hudson.model.Run;
+import org.assertj.core.api.Assertions;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -103,9 +104,9 @@ public class S3UploadStepTransferManagerIntegrationTest {
 
 		Assert.assertEquals(1, captor.getValue().size());
 		Assert.assertEquals("test.txt", ((File)captor.getValue().get(0)).getName());
-		Assert.assertTrue(((File)captor.getValue().get(0)).getPath().endsWith("/subdir/test.txt"));
-		Assert.assertTrue(captorDirectory.getValue().getPath().endsWith("/work"));
-		Assert.assertFalse(captorDirectory.getValue().getPath().contains("subdir"));
+		Assertions.assertThat(((File)captor.getValue().get(0)).getPath()).matches("^.*subdir.test.txt$");
+		Assertions.assertThat(captorDirectory.getValue().getPath()).endsWith("work");
+		Assertions.assertThat(captorDirectory.getValue().getPath()).doesNotContain("subdir");
 	}
 
 	@Test

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTransferManagerIntegrationTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTransferManagerIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.taimos.pipeline.aws;
+
+import com.amazonaws.client.builder.AwsSyncClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.transfer.MultipleFileUpload;
+import com.amazonaws.services.s3.transfer.ObjectMetadataProvider;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import hudson.model.Run;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+@For(S3UploadStep.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AWSClientFactory.class, TransferManagerBuilder.class})
+@PowerMockIgnore("javax.crypto.*")
+public class S3UploadStepTransferManagerIntegrationTest {
+
+	private TransferManager transferManager;
+
+	@ClassRule
+	public static BuildWatcher buildWatcher = new BuildWatcher();
+
+	@Rule
+	public JenkinsRule jenkinsRule = new JenkinsRule();
+
+	@Before
+	public void setupSdk() throws Exception {
+		PowerMockito.mockStatic(AWSClientFactory.class);
+		AmazonS3 amazonS3 = PowerMockito.mock(AmazonS3.class);
+		PowerMockito.when(AWSClientFactory.create(Mockito.any(AwsSyncClientBuilder.class), Mockito.any(StepContext.class)))
+				.thenReturn(amazonS3);
+
+		PowerMockito.mockStatic(TransferManagerBuilder.class);
+		transferManager = Mockito.mock(TransferManager.class);
+		TransferManagerBuilder transferManagerBuilder = PowerMockito.mock(TransferManagerBuilder.class);
+		PowerMockito.when(TransferManagerBuilder.standard()).thenReturn(transferManagerBuilder);
+		PowerMockito.when(transferManagerBuilder.withS3Client(Mockito.any(AmazonS3.class))).thenReturn(transferManagerBuilder);
+		PowerMockito.when(transferManagerBuilder.build()).thenReturn(transferManager);
+	}
+
+	@Test
+	public void useFileListUploaderWhenIncludePathPatternDefined() throws Exception {
+		WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "S3UploadStepTest");
+		job.setDefinition(new CpsFlowDefinition(""
+				+ "node {\n"
+				+ "  writeFile file: 'work/subdir/test.txt', text: 'Hello!'\n"
+				+ "  s3Upload(bucket: 'test-bucket', includePathPattern: '**/*.txt', workingDir: 'work')"
+				+ "}\n", true)
+		);
+
+		MultipleFileUpload upload = Mockito.mock(MultipleFileUpload.class);
+		Mockito.when(transferManager.uploadFileList(Mockito.eq("test-bucket"), Mockito.eq(""), Mockito.any(File.class), Mockito.any(List.class), Mockito.any(ObjectMetadataProvider.class)))
+				.thenReturn(upload);
+		Mockito.when(upload.getSubTransfers()).thenReturn(Collections.emptyList());
+
+		jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
+
+		ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+		ArgumentCaptor<File> captorDirectory = ArgumentCaptor.forClass(File.class);
+
+		Mockito.verify(transferManager).uploadFileList(
+				Mockito.eq("test-bucket"),
+				Mockito.eq(""),
+				captorDirectory.capture(),
+				captor.capture(),
+				Mockito.any(ObjectMetadataProvider.class));
+		Mockito.verify(upload).getSubTransfers();
+		Mockito.verify(upload).waitForCompletion();
+		Mockito.verifyNoMoreInteractions(transferManager, upload);
+
+		Assert.assertEquals(1, captor.getValue().size());
+		Assert.assertEquals("test.txt", ((File)captor.getValue().get(0)).getName());
+		Assert.assertTrue(((File)captor.getValue().get(0)).getPath().endsWith("/subdir/test.txt"));
+		Assert.assertTrue(captorDirectory.getValue().getPath().endsWith("/work"));
+		Assert.assertFalse(captorDirectory.getValue().getPath().contains("subdir"));
+	}
+
+	@Test
+	public void shouldNotUploadAnythingWhenPatternDoNotMatchAnyFile() throws Exception {
+		WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "S3UploadStepTest");
+		job.setDefinition(new CpsFlowDefinition(""
+				+ "node {\n"
+				+ "  writeFile file: 'work/subdir/test.txt', text: 'Hello!'\n"
+				+ "  s3Upload(bucket: 'test-bucket', includePathPattern: '**/*.no-match', workingDir: 'work')"
+				+ "}\n", true)
+		);
+
+		Run run = jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
+		jenkinsRule.assertLogContains("Nothing to upload", run);
+
+		Mockito.verifyNoMoreInteractions(transferManager);
+	}
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix https://github.com/jenkinsci/pipeline-aws-plugin/issues/154


* **What is the current behavior?** (You can also link to an open issue here)
s3Upload omits source path, if includePathPattern matches just one file


* **What is the new behavior (if this is a feature change)?**
Retain path if s3Upload parameter includePathPattern is defined.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
There is minor semantical change, but after this change behavior is more consistent


* **Other information**: