### PR TITLE
Add redirect location option to s3Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ ec2ShareAmi(
 
 ## current master
 * add `parent` argument to `listAWSAccounts`
+* Add redirect location option to `s3Upload`
 
 ## 1.36
 * add `jenkinsStackUpdateStatus` to stack outputs. Specifies if stack was modified

--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ s3Upload(file: 'foo.txt', bucket: 'my-bucket', path: 'path/to/target/file.txt', 
 s3upload(file: 'bar-dir', bucket: 'my-bucket', path: 'path/to/target', kmsId: 'alias/bar')
 ```
 
+A redirect location can be added to uploaded files.
+
+```groovy
+s3Upload(file: 'file.txt', bucket: 'my-bucket', redirectLocation: '/redirect')
+```
+
 ### s3Download
 
 Download a file/folder from S3 to the local workspace.

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
@@ -45,4 +45,7 @@
 	<f:entry title="${%Enable Payload Signing}" field="payloadSigningEnabled">
 		<f:checkbox />
 	</f:entry>
+	<f:entry title="${%Redirect Location}" field="redirectLocation">
+		<f:textbox />
+	</f:entry>
 </j:jelly>

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -38,12 +38,14 @@ public class S3UploadStepTest {
 		step.setAcl(CannedAccessControlList.PublicRead);
 		step.setCacheControl("my-cachecontrol");
 		step.setSseAlgorithm("AES256");
+		step.setRedirectLocation("/redirect");
 		Assert.assertEquals("my-file", step.getFile());
 		Assert.assertEquals("my-bucket", step.getBucket());
 		Assert.assertEquals(CannedAccessControlList.PublicRead, step.getAcl());
 		Assert.assertEquals("my-cachecontrol", step.getCacheControl());
 		Assert.assertEquals("AES256", step.getSseAlgorithm());
 		Assert.assertEquals("alias/foo", step.getKmsId());
+		Assert.assertEquals("/redirect", step.getRedirectLocation());
 	}
 
 	@Test


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature: This adds a `redirectLocation` option to the `s3Upload` step. 

* **What is the current behavior?** (You can also link to an open issue here)
This option is currently not supported.

* **What is the new behavior (if this is a feature change)?**
Specifying a `redirectLocation` corresponds to setting the `x-amz-website-redirect-location` header for the uploaded object.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No.

* **Other information**:
N/A