### PR TITLE
DatatypeConverter replaced with Base64 decoder

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/InvokeLambdaStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/InvokeLambdaStep.java
@@ -24,7 +24,7 @@ package de.taimos.pipeline.aws;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -159,7 +159,7 @@ public class InvokeLambdaStep extends Step {
 		}
 
 		private String getLogResult(InvokeResult result) {
-			return new String(DatatypeConverter.parseBase64Binary(result.getLogResult()), StandardCharsets.UTF_8);
+			return new String(Base64.getDecoder().decode(result.getLogResult()), StandardCharsets.UTF_8);
 		}
 
 	}


### PR DESCRIPTION
The DatatypeConverter was part of the javax.xml.bind and therefore needs
to be replaced with Base64 decoder from the java util packages to smooth
transition to Java9.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Is one part of removing javax.xml.bind classes to smooth transition to java 9 where this package is removed.


* **What is the current behavior?** (You can also link to an open issue here)
https://issues.jenkins-ci.org/browse/JENKINS-55954


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No change required.


* **Other information**: