### PR TITLE
Provide S3 Upload from String Source to s3Upload method

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ s3Upload(file: 'file.txt', bucket: 'my-bucket', redirectLocation: '/redirect')
 Creating an S3 object by creating the file whose contents is the provided text argument.
 
 ```groovy
-s3Upload(file: 'file.txt', bucket: 'my-bucket', text: 'Some Text Content')
-s3Upload(file: 'file.txt', bucket: 'my-bucket', text: 'Some Text Content', path: 'path/to/targetFolder/')
+s3Upload(path: 'file.txt', bucket: 'my-bucket', text: 'Some Text Content')
+s3Upload(path: 'path/to/targetFolder/file.txt', bucket: 'my-bucket', text: 'Some Text Content')
 ```
 
 ### s3Download

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ files = s3FindFiles(pathStyleAccessEnabled: true, bucket:'my-bucket')
 
 ### s3Upload
 
-Upload a file/folder from the workspace to an S3 bucket.
+Upload a file/folder from the workspace (or a String) to an S3 bucket.
 If the `file` parameter denotes a directory, the complete directory including all subfolders will be uploaded.
 
 ```groovy
@@ -221,6 +221,13 @@ A redirect location can be added to uploaded files.
 
 ```groovy
 s3Upload(file: 'file.txt', bucket: 'my-bucket', redirectLocation: '/redirect')
+```
+
+Creating an S3 object by creating the file whose contents is the provided text argument.
+
+```groovy
+s3Upload(file: 'file.txt', bucket: 'my-bucket', text: 'Some Text Content')
+s3Upload(file: 'file.txt', bucket: 'my-bucket', text: 'Some Text Content', path: 'path/to/targetFolder/')
 ```
 
 ### s3Download
@@ -653,6 +660,7 @@ ec2ShareAmi(
 ## current master
 * add `parent` argument to `listAWSAccounts`
 * Add redirect location option to `s3Upload`
+* Add ability to upload a String to an S3 object by adding `text` option to `s3Upload`
 
 ## 1.36
 * add `jenkinsStackUpdateStatus` to stack outputs. Specifies if stack was modified

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -291,7 +291,7 @@ public class S3UploadStep extends AbstractS3Step {
 
 			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
 			Preconditions.checkArgument(file != null || includePathPattern != null, "File or IncludePathPattern must not be null");
-			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be used together.");
+			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be use together");
 
 			final List<FilePath> children = new ArrayList<>();
 			final FilePath dir;

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -292,7 +292,6 @@ public class S3UploadStep extends AbstractS3Step {
 			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
 			Preconditions.checkArgument(file != null || includePathPattern != null, "File or IncludePathPattern must not be null");
 			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be used together.");
-			Preconditions.checkArgument(text != null && file != null, "File and Text cannot be used together.");
 
 			final List<FilePath> children = new ArrayList<>();
 			final FilePath dir;

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.nio.charset.Charset;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -398,7 +399,7 @@ public class S3UploadStep extends AbstractS3Step {
 					.withS3Client(AWSClientFactory.create(this.amazonS3ClientOptions.createAmazonS3ClientBuilder(), this.envVars))
 					.build();
 
-			byte[] bytes = this.text.getBytes();
+			byte[] bytes = this.text.getBytes(Charset.forName("UTF-8"));
 			PutObjectRequest request = null;
 			ObjectMetadata metas = new ObjectMetadata();
 

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -291,8 +291,8 @@ public class S3UploadStep extends AbstractS3Step {
 
 			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
 			Preconditions.checkArgument(file != null || includePathPattern != null, "File or IncludePathPattern must not be null");
-			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be use together");
-			Preconditions.checkArgument(text == null || file != null, "If you provide Text aregument, you must also provide a File name.");
+			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be used together.");
+			Preconditions.checkArgument(text != null && file != null, "File and Text cannot be used together.");
 
 			final List<FilePath> children = new ArrayList<>();
 			final FilePath dir;
@@ -332,22 +332,20 @@ public class S3UploadStep extends AbstractS3Step {
 				metas.setContentLength(bytes.length);
 
 				// Add metadata
-				if ((metadatas != null && metadatas.size() > 0) || (cacheControl != null && !cacheControl.isEmpty()) || (contentEncoding != null && !contentEncoding.isEmpty()) || (contentType != null && !contentType.isEmpty()) || (sseAlgorithm != null && !sseAlgorithm.isEmpty())) {
-					if (metadatas != null && metadatas.size() > 0) {
-						metas.setUserMetadata(metadatas);
-					}
-					if (cacheControl != null && !cacheControl.isEmpty()) {
-						metas.setCacheControl(cacheControl);
-					}
-					if (contentEncoding != null && !contentEncoding.isEmpty()) {
-						metas.setContentEncoding(contentEncoding);
-					}
-					if (contentType != null && !contentType.isEmpty()) {
-						metas.setContentType(contentType);
-					}
-					if (sseAlgorithm != null && !sseAlgorithm.isEmpty()) {
-						metas.setSSEAlgorithm(sseAlgorithm);
-					}
+				if (metadatas != null && metadatas.size() > 0) {
+					metas.setUserMetadata(metadatas);
+				}
+				if (cacheControl != null && !cacheControl.isEmpty()) {
+					metas.setCacheControl(cacheControl);
+				}
+				if (contentEncoding != null && !contentEncoding.isEmpty()) {
+					metas.setContentEncoding(contentEncoding);
+				}
+				if (contentType != null && !contentType.isEmpty()) {
+					metas.setContentType(contentType);
+				}
+				if (sseAlgorithm != null && !sseAlgorithm.isEmpty()) {
+					metas.setSSEAlgorithm(sseAlgorithm);
 				}
 
 				request = new PutObjectRequest(bucket, path, new ByteArrayInputStream(bytes), metas);

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/config.jelly
@@ -3,6 +3,9 @@
 	<f:entry title="${%File}" field="file">
 		<f:textbox />
 	</f:entry>
+	<f:entry title="${%Text}" field="text">
+		<f:textbox />
+	</f:entry>
 	<f:entry title="${%Bucket}" field="bucket">
 		<f:textbox />
 	</f:entry>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-text.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help-text.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+	This is the text to be copied up to S3.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3UploadStep/help.html
@@ -21,5 +21,6 @@
 	<p>
 		Upload a file/folder from the workspace to an S3 bucket.
 		If the file parameter denotes a directory, then the complete directory (including all subfolders) will be uploaded.
+		If text is provided, upload the text as the provided filename in the remote S3 bucket.
 	</p>
 </div>

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -98,15 +98,4 @@ public class S3UploadStepTest {
 		Assert.assertEquals("File and IncludePathPattern cannot be use together", t.getMessage());
 	}
 
-	@Test
-	public void textArgumentMustBeUsedWithFileArgument() throws Exception {
-		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
-		step.setFile("file.txt");
-		step.setText("uploadable text");
-		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
-		Throwable t = Assertions.catchThrowable(execution::run);
-		Assert.assertTrue(t instanceof IllegalArgumentException);
-		Assert.assertEquals("If you provide Text aregument, you must also provide a File name.", t.getMessage());
-	}
-
 }

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -34,12 +34,14 @@ public class S3UploadStepTest {
 	public void gettersWorkAsExpectedForFileCase() throws Exception {
 		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
 		step.setFile("my-file");
+		step.setText("my content text");
 		step.setKmsId("alias/foo");
 		step.setAcl(CannedAccessControlList.PublicRead);
 		step.setCacheControl("my-cachecontrol");
 		step.setSseAlgorithm("AES256");
 		step.setRedirectLocation("/redirect");
 		Assert.assertEquals("my-file", step.getFile());
+		Assert.assertEquals("my content text", step.getText());
 		Assert.assertEquals("my-bucket", step.getBucket());
 		Assert.assertEquals(CannedAccessControlList.PublicRead, step.getAcl());
 		Assert.assertEquals("my-cachecontrol", step.getCacheControl());
@@ -94,6 +96,17 @@ public class S3UploadStepTest {
 		Throwable t = Assertions.catchThrowable(execution::run);
 		Assert.assertTrue(t instanceof IllegalArgumentException);
 		Assert.assertEquals("File and IncludePathPattern cannot be use together", t.getMessage());
+	}
+
+	@Test
+	public void textArgumentMustBeUsedWithFileArgument() throws Exception {
+		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
+		step.setFile("file.txt");
+		step.setText("uploadable text");
+		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
+		Throwable t = Assertions.catchThrowable(execution::run);
+		Assert.assertTrue(t instanceof IllegalArgumentException);
+		Assert.assertEquals("If you provide Text aregument, you must also provide a File name.", t.getMessage());
 	}
 
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X ] The commit message describes your change
- [X ] Tests for the changes have been added if possible (for bug fixes / features)
- [ X] Docs have been added / updated (for bug fixes / features)
- [X ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds the ability to upload a string as an S3 object.  I was unable to find any unit tests that exercise the base functionality of the s3Upload method, so I didn't find any unit tests to replicate in order to test this feature.  I added support for the new optional parameter to the existing unit tests.


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/jenkinsci/pipeline-aws-plugin/issues/122


* **What is the new behavior (if this is a feature change)?**
Add an optional argument to s3Upload that allows user to supply a String. If that argument is present, the upload sends the contents of the String to be injected as the content of the file in S3.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
Non-breaking. Addition of optional argument.

