### PR TITLE
Adds S3DoesObjectExistStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This plugins adds Jenkins pipeline steps to interact with the AWS API.
 * [s3Download](#s3download)
 * [s3Copy](#s3copy)
 * [s3Delete](#s3delete)
+* [s3DoesObjectExist](#s3doesobjectexist)
 * [s3FindFiles](#s3findfiles)
 * [s3PresignURL](#s3presignurl)
 * [cfnValidate](#cfnvalidate)
@@ -153,6 +154,7 @@ s3Upload(pathStyleAccessEnabled: true, payloadSigningEnabled: true, file:'file.t
 s3Copy(pathStyleAccessEnabled: true, fromBucket:'my-bucket', fromPath:'path/to/source/file.txt', toBucket:'other-bucket', toPath:'path/to/destination/file.txt')
 s3Delete(pathStyleAccessEnabled: true, bucket:'my-bucket', path:'path/to/source/file.txt')
 s3Download(pathStyleAccessEnabled: true, file:'file.txt', bucket:'my-bucket', path:'path/to/source/file.txt', force:true)
+exists = s3DoesObjectExist(pathStyleAccessEnabled: true, bucket:'my-bucket', path:'path/to/source/file.txt')
 files = s3FindFiles(pathStyleAccessEnabled: true, bucket:'my-bucket')
 
 ```
@@ -258,6 +260,14 @@ If the path ends in a "/", then the path will be interpreted to be a folder, and
 ```groovy
 s3Delete(bucket:'my-bucket', path:'path/to/source/file.txt')
 s3Delete(bucket:'my-bucket', path:'path/to/sourceFolder/')
+```
+
+### s3DoesObjectExist
+
+Check if object exists in S3 bucket.
+
+```groovy
+exists = s3DoesObjectExist(bucket:'my-bucket', path:'path/to/source/file.txt')
 ```
 
 ### s3FindFiles
@@ -658,6 +668,7 @@ ec2ShareAmi(
 # Changelog
 
 ## current master
+* add `s3DoesObjectExist` step
 * add `parent` argument to `listAWSAccounts`
 * Add redirect location option to `s3Upload`
 * Add Xerces dependency to fix #117

--- a/src/main/java/de/taimos/pipeline/aws/S3DoesObjectExistStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3DoesObjectExistStep.java
@@ -1,0 +1,121 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2016 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.base.Preconditions;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Set;
+
+/**
+ * The S3DoesObjectExistStep returns a boolean signalling whether an object exists in S3 or not.
+ * <p>
+ * This thus accepts a bucket and a path.
+ */
+public class S3DoesObjectExistStep extends AbstractS3Step {
+	/**
+	 * This is the bucket name.
+	 */
+	private final String bucket;
+	/**
+	 * This is the path to limit the search to.
+	 */
+	private final String path;
+
+	@DataBoundConstructor
+	public S3DoesObjectExistStep(String bucket, String path, boolean pathStyleAccessEnabled, boolean payloadSigningEnabled) {
+		super(pathStyleAccessEnabled, payloadSigningEnabled);
+		this.bucket = bucket;
+		this.path = path;
+	}
+
+	public String getBucket() {
+		return this.bucket;
+	}
+
+	public String getPath() {
+		return this.path;
+	}
+
+	@Override
+	public StepExecution start(StepContext context) throws Exception {
+		return new S3DoesObjectExistStep.Execution(this, context);
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requires(TaskListener.class, EnvVars.class, FilePath.class);
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "s3DoesObjectExist";
+		}
+
+		@Override
+		public String getDisplayName() {
+			return "Check if object exists in S3";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Boolean> {
+		private static final long serialVersionUID = 1L;
+
+		private final transient S3DoesObjectExistStep step;
+
+		public Execution(S3DoesObjectExistStep step, StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		public Boolean run() throws Exception {
+			final String bucket = this.step.getBucket();
+			final String path = this.step.getPath();
+
+			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
+			Preconditions.checkArgument(path != null && !path.isEmpty(), "Path must not be null or empty");
+
+			this.getContext().get(TaskListener.class).getLogger().format("Searching s3://%s for object:'%s'%n", bucket, path);
+
+			AmazonS3 s3Client = AWSClientFactory.create(Execution.this.step.createS3ClientOptions().createAmazonS3ClientBuilder(), Execution.this.getContext());
+
+			Boolean stepResult = s3Client.doesObjectExist(bucket, path);
+
+			this.getContext().get(TaskListener.class).getLogger().println("Search complete");
+			return stepResult;
+		}
+	}
+}

--- a/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/config.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:entry title="${%Bucket}" field="bucket">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Path}" field="path">
+		<f:textbox />
+	</f:entry>
+	<f:entry title="${%Enable Path-style Access}" field="pathStyleAccessEnabled">
+		<f:checkbox />
+	</f:entry>
+	<f:entry title="${%Enable Payload Signing}" field="payloadSigningEnabled">
+		<f:checkbox />
+	</f:entry>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-bucket.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-bucket.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+	This is the bucket to use.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-path.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-path.html
@@ -1,0 +1,23 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+	This is the path inside the bucket to use.
+	<i>Do not begin with a leading "/".</i>
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-pathStyleAccessEnabled.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-pathStyleAccessEnabled.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+	Enabled/Disable Path-style Access for AWS S3.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-payloadSigningEnabled.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help-payloadSigningEnabled.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+	Enabled/Disable Payload Signing for AWS S3.
+</div>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DoesObjectExistStep/help.html
@@ -1,0 +1,24 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+	<p>
+		Check if object exists in S3 bucket.
+	</p>
+</div>

--- a/src/test/java/de/taimos/pipeline/aws/S3DoesObjectExistStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3DoesObjectExistStepTest.java
@@ -1,0 +1,34 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2017 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.taimos.pipeline.aws;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class S3DoesObjectExistStepTest {
+	@Test
+	public void gettersWorkAsExpected() throws Exception {
+		S3DoesObjectExistStep step = new S3DoesObjectExistStep("my-bucket", "my-object", false, false);
+		Assert.assertEquals("my-bucket", step.getBucket());
+		Assert.assertEquals("my-object", step.getPath());
+	}
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces a new feature (`s3DoesObjectExist` step) together with documentation and changelog updates.


* **What is the current behavior?** (You can also link to an open issue here)
Currently, the feature is not part of `pipeline-aws-plugin`. However, it is exposed in `com.amazonaws.services.s3.AmazonS3` client. Thus, it can be easily added to the plugin.


* **What is the new behavior (if this is a feature change)?**
The new feature is `s3DoesObjectExist` step. It takes a `bucket` and a `path` as **required** arguments and returns a boolean signalling whether the object (specified by the path argument) exists or not in the specified bucket.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No, this PR does not introduce any breaking changes.


* **Other information**:
The use case for the new feature could/will be to check whether an object exists in S3 ahead of starting the download. Thus, getting rid of the need to rely on exception handling when trying to download an object that does not exist.

- [x] Tests have been run before creating the PR: `mvn test`