### PR TITLE
Add a flag to reduce logging in `s3Upload` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ s3Upload(path: 'file.txt', bucket: 'my-bucket', text: 'Some Text Content')
 s3Upload(path: 'path/to/targetFolder/file.txt', bucket: 'my-bucket', text: 'Some Text Content')
 ```
 
+Log messages can be less verbose. Disable it when you feel the logs are excessive but you will lose the visibility of what files having been uploaded to S3.
+
+```groovy
+s3Upload(path: 'source/path/', bucket: 'my-bucket', verbose: false)
+```
+
 ### s3Download
 
 Download a file/folder from S3 to the local workspace.
@@ -350,7 +356,7 @@ Additionally you can specify a list of tags that are set on the stack and all re
 
 The step returns the outputs of the stack as a map. It also contains special values prefixed with `jenkins`:
 
-* `jenkinsStackUpdateStatus` - "true"/"false" whether the stack was modified or not 
+* `jenkinsStackUpdateStatus` - "true"/"false" whether the stack was modified or not
 
 When cfnUpdate creates a stack and the creation fails, the stack is deleted instead of being left in a broken state.
 
@@ -441,7 +447,7 @@ Additionally you can specify a list of tags that are set on the stack and all re
 
 The step returns the outputs of the stack as a map. It also contains special values prefixed with `jenkins`:
 
-* `jenkinsStackUpdateStatus` - "true"/"false" whether the stack was modified or not 
+* `jenkinsStackUpdateStatus` - "true"/"false" whether the stack was modified or not
 
 
 To prevent running into rate limiting on the AWS API you can change the default polling interval of 1000 ms using the parameter `pollIntervall`. Using the value `0` disables event printing.


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)

* **What kind of change does this PR introduce?**
It's a new feature of the `s3Upload` step

* **What is the current behavior?**
One line `Finished: Uploading to <bucket>/<key>` is generated for each file gets uploaded to S3. When there are thousands of files, the log messages become excessive and sometimes overload the Jenkins master.

* **What is the new behavior (if this is a feature change)?**
When `verbose` is set to `false`, no more instances of `Finished: Uploading to ...` will be logged.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No
