### PR TITLE
Bug Fix: Close TransferManger threads from aws-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ ec2ShareAmi(
 * Add Xerces dependency to fix #117
 * Add ability to upload a String to an S3 object by adding `text` option to `s3Upload`
 * Add support for SessionToken when using iamMfaToken #170
+* Fix instances of TransferManger from aws-sdk were never closed properly
 
 ## 1.36
 * add `jenkinsStackUpdateStatus` to stack outputs. Specifies if stack was modified

--- a/src/main/java/de/taimos/pipeline/aws/S3CopyStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3CopyStep.java
@@ -248,13 +248,18 @@ public class S3CopyStep extends AbstractS3Step {
 			TransferManager mgr = TransferManagerBuilder.standard()
 					.withS3Client(AWSClientFactory.create(s3ClientOptions.createAmazonS3ClientBuilder(), envVars))
 					.build();
-			final Copy copy = mgr.copy(request);
-			copy.addProgressListener((ProgressListener) progressEvent -> {
-				if (progressEvent.getEventType() == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
-					listener.getLogger().println("Finished: " + copy.getDescription());
-				}
-			});
-			copy.waitForCompletion();
+			try {
+				final Copy copy = mgr.copy(request);
+				copy.addProgressListener((ProgressListener) progressEvent -> {
+					if (progressEvent.getEventType() == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
+						listener.getLogger().println("Finished: " + copy.getDescription());
+					}
+				});
+				copy.waitForCompletion();
+			}
+			finally{
+				mgr.shutdownNow();
+			}
 
 			listener.getLogger().println("Copy complete");
 			return String.format("s3://%s/%s", toBucket, toPath);

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTransferManagerIntegrationTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTransferManagerIntegrationTest.java
@@ -100,6 +100,7 @@ public class S3UploadStepTransferManagerIntegrationTest {
 				Mockito.any(ObjectMetadataProvider.class));
 		Mockito.verify(upload).getSubTransfers();
 		Mockito.verify(upload).waitForCompletion();
+		Mockito.verify(transferManager).shutdownNow();
 		Mockito.verifyNoMoreInteractions(transferManager, upload);
 
 		Assert.assertEquals(1, captor.getValue().size());


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ✔️ ] The commit message describes your change
- [ ✔️ ] Tests for the changes have been added if possible (for bug fixes / features)
- [  ] Docs have been added / updated (for bug fixes / features)
- [ ✔️ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
S3Copy, S3Download, and S3Upload all create at least one instance of a TransferManger from the aws-sdk, but none of them ever close it. Failing to shut this down results in threads and the aws client being left open.

* **What is the new behavior (if this is a feature change)?**
Close the TransferManger

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
Nope