### PR TITLE
If cloudformation stack IN_REVIEW, then a change request needs to be CREATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ ec2ShareAmi(
 # Changelog
 
 ## current master
+* fix CloudFormation CreateChangeSet for a stack with IN_REVIEW state
 
 ## 1.39
 * add `notificationARNs` argument to `cfnUpdate` and `cfnUpdateStackSet`

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
@@ -65,6 +65,7 @@ public class CloudformationStackTests {
 	@Test
 	public void stackExists() {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 		Mockito.when(client.describeStacks(new DescribeStacksRequest()
@@ -79,6 +80,7 @@ public class CloudformationStackTests {
 	@Test
 	public void stackDoesNotExists() {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 		AmazonCloudFormationException ex = new AmazonCloudFormationException("foo");
@@ -93,6 +95,7 @@ public class CloudformationStackTests {
 	@Test
 	public void changeSetExists() {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
@@ -107,6 +110,7 @@ public class CloudformationStackTests {
 	@Test
 	public void executeChangeSetWithChanges() throws ExecutionException {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
@@ -150,6 +154,7 @@ public class CloudformationStackTests {
 	@Test
 	public void changeSetDoesNotExists() {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 		AmazonCloudFormationException ex = new AmazonCloudFormationException("foo");
@@ -165,6 +170,7 @@ public class CloudformationStackTests {
 	@Test
 	public void describeStack() {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
@@ -180,6 +186,8 @@ public class CloudformationStackTests {
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
+		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
+				.thenReturn(new DescribeStacksResult());
 
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 
@@ -205,6 +213,8 @@ public class CloudformationStackTests {
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
+		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
+				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withStackStatus("CREATE_COMPLETE")));
 
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 
@@ -214,6 +224,33 @@ public class CloudformationStackTests {
 		Mockito.verify(client).createChangeSet(captor.capture());
 		Assertions.assertThat(captor.getValue()).isEqualTo(new CreateChangeSetRequest()
 																   .withChangeSetType(ChangeSetType.UPDATE)
+																   .withStackName("foo")
+																   .withTemplateBody("templateBody")
+																   .withCapabilities(Capability.values())
+																   .withParameters(Collections.emptyList())
+																   .withChangeSetName("c1")
+																   .withRoleARN("myarn")
+		);
+		Mockito.verify(this.eventPrinter).waitAndPrintChangeSetEvents(Mockito.eq("foo"), Mockito.eq("c1"), Mockito.any(Waiter.class), Mockito.eq(PollConfiguration.DEFAULT));
+	}
+
+	@Test
+	public void createStackWithStackChangeSetReviewInProgress() throws ExecutionException {
+		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
+		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
+		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
+		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
+				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withStackStatus("REVIEW_IN_PROGRESS")));
+
+		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
+
+		stack.createChangeSet("c1", "templateBody", null, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), PollConfiguration.DEFAULT, ChangeSetType.UPDATE, "myarn", null);
+
+		ArgumentCaptor<CreateChangeSetRequest> captor = ArgumentCaptor.forClass(CreateChangeSetRequest.class);
+		Mockito.verify(client).createChangeSet(captor.capture());
+		Assertions.assertThat(captor.getValue()).isEqualTo(new CreateChangeSetRequest()
+																   .withChangeSetType(ChangeSetType.CREATE)
 																   .withStackName("foo")
 																   .withTemplateBody("templateBody")
 																   .withCapabilities(Capability.values())


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
If a stack is IN_REVIEW, it exists, so the current logic attempts to do an UPDATE, but that fails with a stack does not exist failure from cloudformation


* **What is the new behavior (if this is a feature change)?**
This forces the CreateChangeSet request to use a change set type of CREATE if the stack is in review.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: