### PR TITLE
ecrLogin: support setting registry ids explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,12 @@ For older versions of docker that need the email parameter use:
 def login = ecrLogin(email:true)
 ```
 
+It's also possible to specify AWS accounts to perform ECR login into:
+
+```groovy
+def login = ecrLogin(registryIds: ['123456789', '987654321'])
+```
+
 ## invokeLambda
 
 Invoke a Lambda function.
@@ -724,6 +730,7 @@ ec2ShareAmi(
 # Changelog
 
 ## current master
+* add `registryIds` argument to `ecrLogin`
 * fix CloudFormation CreateChangeSet for a stack with IN_REVIEW state
 * Add lambdaCleanupVersions
 

--- a/src/main/java/de/taimos/pipeline/aws/ECRLoginStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/ECRLoginStep.java
@@ -21,6 +21,7 @@
 
 package de.taimos.pipeline.aws;
 
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.codec.Charsets;
@@ -44,6 +45,7 @@ import hudson.Extension;
 public class ECRLoginStep extends Step {
 
 	private Boolean email = false;
+	private List<String> registryIds;
 
 	@DataBoundConstructor
 	public ECRLoginStep() {
@@ -62,6 +64,15 @@ public class ECRLoginStep extends Step {
 
 	public Boolean getEmail() {
 		return this.email;
+	}
+
+	@DataBoundSetter
+	public void setRegistryIds(List<String> registryIds) {
+		this.registryIds = registryIds;
+	}
+
+	public List<String> getRegistryIds() {
+		return this.registryIds;
 	}
 
 	@Extension
@@ -96,7 +107,12 @@ public class ECRLoginStep extends Step {
 		protected String run() throws Exception {
 			AmazonECR ecr = AWSClientFactory.create(AmazonECRClientBuilder.standard(), this.getContext());
 
-			GetAuthorizationTokenResult token = ecr.getAuthorizationToken(new GetAuthorizationTokenRequest());
+			GetAuthorizationTokenRequest request = new GetAuthorizationTokenRequest();
+			List<String> registryIds;
+			if((registryIds = this.step.getRegistryIds()) != null) {
+				request.setRegistryIds(registryIds);
+			}
+			GetAuthorizationTokenResult token = ecr.getAuthorizationToken(request);
 
 			if (token.getAuthorizationData().size() != 1) {
 				throw new RuntimeException("Did not get authorizationData from AWS");


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Support of non-default AWS account for ECR login

* **What is the current behavior?** (You can also link to an open issue here)

ECR login is performed into default AWS account

* **What is the new behavior (if this is a feature change)?**

ECR login is performed into specified AWS account, or default one if not specified

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)

No

* **Other information**: