### PR TITLE
Add resiliancy features for cfnUpdateStackSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ ec2ShareAmi(
 * Add lambdaCleanupVersions
 * Add ecrSetRepositoryPolicy
 * Add batching support for cfnUpdateStackSet
+* Retry stack set deployments on LimitExceededException when there are too many StackSet operations occuring.
 
 ## 1.39
 * add `notificationARNs` argument to `cfnUpdate` and `cfnUpdateStackSet`

--- a/README.md
+++ b/README.md
@@ -532,6 +532,12 @@ To set a operation preferences:
   cfnUpdateStackSet(stackSet:'myStackSet', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', operationPreferences: [failureToleranceCount: 5])
 ```
 
+When the stack set gets really big, the recommendation from AWS is to batch the update requests. This option is *not* part of the AWS API, but is an implementation to facilitate updating a large stack set.
+To automatically batch via region (find all stack instances, group them by region, and submit each region separately): (
+```groovy
+  cfnUpdateStackSet(stackSet:'myStackSet', url:'https://s3.amazonaws.com/my-templates-bucket/template.yaml', batchingOptions: [regions: true])
+```
+
 ## cfnDeleteStackSet
 
 Deletes a stack set.
@@ -762,6 +768,7 @@ ec2ShareAmi(
 * fix CloudFormation CreateChangeSet for a stack with IN_REVIEW state
 * Add lambdaCleanupVersions
 * Add ecrSetRepositoryPolicy
+* Add batching support for cfnUpdateStackSet
 
 ## 1.39
 * add `notificationARNs` argument to `cfnUpdate` and `cfnUpdateStackSet`

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/BatchingOptions.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/BatchingOptions.java
@@ -1,0 +1,16 @@
+package de.taimos.pipeline.aws.cloudformation.stacksets;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class BatchingOptions {
+	private final boolean regions;
+
+	@DataBoundConstructor
+	public BatchingOptions(boolean regions) {
+		this.regions = regions;
+	}
+
+	public boolean isRegions() {
+		return regions;
+	}
+}

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSetTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CloudFormationStackSetTest.java
@@ -15,14 +15,13 @@ import java.util.UUID;
 
 public class CloudFormationStackSetTest {
 
-	private TaskListener listener;
 	private AmazonCloudFormation client;
 	private SleepStrategy sleepStrategy;
 	private CloudFormationStackSet stackSet;
 
 	@Before
 	public void setup() {
-		listener = Mockito.mock(TaskListener.class);
+		TaskListener listener = Mockito.mock(TaskListener.class);
 		Mockito.when(listener.getLogger()).thenReturn(System.out);
 		client = Mockito.mock(AmazonCloudFormation.class);
 		sleepStrategy = Mockito.mock(SleepStrategy.class);
@@ -167,7 +166,9 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update("body", null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
+		UpdateStackSetResult result = stackSet.update("body", null, new UpdateStackSetRequest()
+				.withParameters(parameter1)
+				.withTags(tag1));
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client).updateStackSet(captor.capture());
@@ -193,7 +194,9 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, "url", Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
+		UpdateStackSetResult result = stackSet.update(null, "url", new UpdateStackSetRequest()
+				.withParameters(parameter1)
+				.withTags(tag1));
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client).updateStackSet(captor.capture());
@@ -203,34 +206,6 @@ public class CloudFormationStackSetTest {
 				.withParameters(parameter1)
 				.withTags(tag1)
 				.withTemplateURL("url")
-		);
-	}
-
-	@Test
-	public void updateAdministratorRoleArn() throws InterruptedException {
-		UpdateStackSetResult expected = new UpdateStackSetResult();
-		Mockito.when(client.updateStackSet(Mockito.any(UpdateStackSetRequest.class)))
-				.thenReturn(expected);
-
-		Parameter parameter1 = new Parameter()
-				.withParameterKey("foo")
-				.withParameterValue("bar");
-		Tag tag1 = new Tag()
-				.withKey("bar")
-				.withValue("baz");
-
-		UpdateStackSetResult result = stackSet.update("body", null, Collections.singletonList(parameter1), Collections.singletonList(tag1), "bar", "baz", null);
-		Assertions.assertThat(result).isSameAs(expected);
-		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
-		Mockito.verify(client).updateStackSet(captor.capture());
-		Assertions.assertThat(captor.getValue()).isEqualTo(new UpdateStackSetRequest()
-				.withStackSetName("foo")
-				.withCapabilities(Capability.values())
-				.withParameters(parameter1)
-				.withAdministrationRoleARN("bar")
-				.withExecutionRoleName("baz")
-				.withTags(tag1)
-				.withTemplateBody("body")
 		);
 	}
 
@@ -247,7 +222,9 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
+		UpdateStackSetResult result = stackSet.update(null, null, new UpdateStackSetRequest()
+				.withParameters(parameter1)
+				.withTags(tag1));
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client).updateStackSet(captor.capture());
@@ -276,8 +253,9 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1),
-				null, null, null);
+		UpdateStackSetResult result = stackSet.update(null, null, new UpdateStackSetRequest()
+				.withParameters(parameter1)
+				.withTags(tag1));
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client, Mockito.times(2)).updateStackSet(captor.capture());
@@ -307,7 +285,9 @@ public class CloudFormationStackSetTest {
 				.withKey("bar")
 				.withValue("baz");
 
-		UpdateStackSetResult result = stackSet.update(null, null, Collections.singletonList(parameter1), Collections.singletonList(tag1), null, null, null);
+		UpdateStackSetResult result = stackSet.update(null, null, new UpdateStackSetRequest()
+				.withParameters(parameter1)
+				.withTags(tag1));
 		Assertions.assertThat(result).isSameAs(expected);
 		ArgumentCaptor<UpdateStackSetRequest> captor = ArgumentCaptor.forClass(UpdateStackSetRequest.class);
 		Mockito.verify(client, Mockito.times(2)).updateStackSet(captor.capture());


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
AWS Stacksets limits the total number of operations (account * region) available in the account. This adds features to support updating large stacksets:
** Automatic batching by region
** Retry on LimitExceededException in cfnUpdateStackSet


* **What is the current behavior?** (You can also link to an open issue here)
large stacksets don't update


* **What is the new behavior (if this is a feature change)?**
multiple, serial operations are done to update the whole stack set


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: