### PR TITLE
fix `cfnExecuteChangeSet` when no resource changes (#210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ elbIsInstanceDeregistered(
 * Add ELB methods to mangage instances during deployemnts ( [elbRegisterInstance](#elbRegisterInstance), [elbDeregisterInstance](#elbDeregisterInstance), [elbIsInstanceRegistered](#elbIsInstanceRegistered), [elbIsInstanceDeregistered](#elbIsInstanceDeregistered) )
 * Add tags to files uploaded with S3Upload
 * Add `createDeployment` step
+* fix `cfnExecuteChangeSet` when no resource change (#210)
 
 ## 1.40
 * add `registryIds` argument to `ecrLogin`

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -243,8 +243,8 @@ public class CloudFormationStack {
 	}
 
 	public Map<String, String> executeChangeSet(String changeSetName, PollConfiguration pollConfiguration) throws ExecutionException {
-		if (!this.changeSetHasChanges(changeSetName) || !this.exists()) {
-			// If the change set has no changes or the stack was not prepared we should simply delete it.
+		if (!this.exists()) {
+			// If the stack was not prepared we should simply delete it.
 			this.listener.getLogger().format("Deleting empty change set %s for stack %s %n", changeSetName, this.stack);
 			DeleteChangeSetRequest req = new DeleteChangeSetRequest().withChangeSetName(changeSetName).withStackName(this.stack);
 			this.client.deleteChangeSet(req);

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
@@ -138,10 +138,10 @@ public class CloudformationStackTests {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
-        Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
-        CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
+		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
+		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 
-        // no resource changes in changeset
+		// no resource changes in changeset
 		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
 													  .withStackName("foo")
 													  .withChangeSetName("bar")
@@ -152,10 +152,10 @@ public class CloudformationStackTests {
 
 		Map<String, String> outputs = stack.executeChangeSet("bar", PollConfiguration.DEFAULT);
 
-        Mockito.verify(client).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
-        Mockito.verify(this.eventPrinter).waitAndPrintStackEvents(Mockito.eq("foo"), Mockito.any(Waiter.class), Mockito.eq(PollConfiguration.DEFAULT));
-        Assertions.assertThat(outputs).containsEntry("bar", "baz").containsEntry("jenkinsStackUpdateStatus", "true");
-    }
+		Mockito.verify(client).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
+		Mockito.verify(this.eventPrinter).waitAndPrintStackEvents(Mockito.eq("foo"), Mockito.any(Waiter.class), Mockito.eq(PollConfiguration.DEFAULT));
+		Assertions.assertThat(outputs).containsEntry("bar", "baz").containsEntry("jenkinsStackUpdateStatus", "true");
+	}
 
 	@Test
 	public void changeSetDoesNotExists() {

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
@@ -111,11 +111,11 @@ public class CloudformationStackTests {
 	public void executeChangeSetWithChanges() throws ExecutionException {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
-		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
-
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
+
+		// with resource changes in changeset
 		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
 													  .withStackName("foo")
 													  .withChangeSetName("bar")
@@ -138,18 +138,24 @@ public class CloudformationStackTests {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
-		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
+        Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
+        CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
+
+        // no resource changes in changeset
 		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
 													  .withStackName("foo")
 													  .withChangeSetName("bar")
 		)).thenReturn(new DescribeChangeSetResult());
+
 		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
-				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withOutputs(new Output().withOutputKey("bar").withOutputValue("baz"))));
+				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withStackStatus("CREATE_COMPLETE").withOutputs(new Output().withOutputKey("bar").withOutputValue("baz"))));
 
 		Map<String, String> outputs = stack.executeChangeSet("bar", PollConfiguration.DEFAULT);
-		Mockito.verify(client, Mockito.never()).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
-		Assertions.assertThat(outputs).containsEntry("bar", "baz").containsEntry("jenkinsStackUpdateStatus", "false");
-	}
+
+        Mockito.verify(client).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
+        Mockito.verify(this.eventPrinter).waitAndPrintStackEvents(Mockito.eq("foo"), Mockito.any(Waiter.class), Mockito.eq(PollConfiguration.DEFAULT));
+        Assertions.assertThat(outputs).containsEntry("bar", "baz").containsEntry("jenkinsStackUpdateStatus", "true");
+    }
 
 	@Test
 	public void changeSetDoesNotExists() {


### PR DESCRIPTION
This might be the case when adding only an Output

* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for #210 


* **What is the current behavior?** (You can also link to an open issue here)
#210 


* **What is the new behavior (if this is a feature change)?**
Even if there are no resource changes, the change set is executed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No


* **Other information**: