### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 /target
 deploy.sh
 work/*
+
+.classpath
+.project
+.factorypath
+.settings/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: mvn install -DskipTests=false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,3 @@
+image: maven:3-openjdk-8
 tasks:
   - init: mvn install -DskipTests=false

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,8 @@
+[ ] 🐞 Bug
+[ ] 🚀 Feature
+[ ] 🛠 Task
+[ ] 📄 Documentation
+
 ### Description
 
 [Description of the bug or feature]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/jenkinsci/pipeline-aws-plugin)
-
-# Status
-
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/pipeline-aws-plugin/master)](https://ci.jenkins.io/job/Plugins/job/pipeline-aws-plugin/job/master/)
 
 # Features

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/jenkinsci/pipeline-aws-plugin)
+
 # Status
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/pipeline-aws-plugin/master)](https://ci.jenkins.io/job/Plugins/job/pipeline-aws-plugin/job/master/)


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitHub and GitLab that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.
