### PR TITLE
Add support for Elastic Beanstalk 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This plugins adds Jenkins pipeline steps to interact with the AWS API.
 * [ebCreateEnvironment](#ebCreateEnvironment)
 * [ebSwapEnvironmentCNAMEs](#ebSwapEnvironmentCNAMEs)
 * [ebWaitOnEnvironmentStatus](#ebWaitOnEnvironmentStatus)
+* [ebWaitOnEnvironmentHealth](#ebWaitOnEnvironmentHealth)
 
 [**see the changelog for release information**](#changelog)
 
@@ -1063,7 +1064,7 @@ ebWaitOnEnvironmentHealth(
 )
 
 // Detect immediately if environment becomes red
-ebWaitOnEnvironmentStatus(
+ebWaitOnEnvironmentHealth(
     applicationName: "my-application",
     environmentName: "temporary",
     health: "Red",

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationStep.java
@@ -1,0 +1,85 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationResult;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public class EBCreateApplicationStep extends Step {
+	private final String applicationName;
+	private String description;
+
+	@DataBoundConstructor
+	public EBCreateApplicationStep(String applicationName) {
+		this.applicationName = applicationName;
+	}
+
+	@Override
+	public StepExecution start(StepContext stepContext) throws Exception {
+		return new Execution(this, stepContext);
+	}
+
+	@DataBoundSetter
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requiresDefault();
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "ebCreateApplication";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Creates a new Elastic Beanstalk application";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+		private static final long serialVersionUID = 1L;
+		private final transient EBCreateApplicationStep step;
+
+		protected Execution(EBCreateApplicationStep step, @Nonnull StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			TaskListener listener = this.getContext().get(TaskListener.class);
+			AWSElasticBeanstalk client = AWSElasticBeanstalkClientBuilder.defaultClient();
+			listener.getLogger().format("Creating application (%s) %n", step.applicationName);
+
+			CreateApplicationRequest request = new CreateApplicationRequest();
+			request.setApplicationName(step.applicationName);
+			request.setDescription(step.description);
+
+			CreateApplicationResult result = client.createApplication(request);
+			listener.getLogger().format("Created application (%s) with arn (%s) %n", step.applicationName, result.getApplication().getApplicationArn());
+
+			return null;
+		}
+	}
+}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationVersionStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationVersionStep.java
@@ -1,0 +1,99 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationVersionRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationVersionResult;
+import com.amazonaws.services.elasticbeanstalk.model.S3Location;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public class EBCreateApplicationVersionStep extends Step {
+	private final String applicationName;
+	private final String versionLabel;
+	private final String s3Bucket;
+	private final String s3Key;
+	private String description;
+
+	@DataBoundConstructor
+	public EBCreateApplicationVersionStep(String applicationName, String versionLabel, String s3Bucket, String s3Key) {
+		this.applicationName = applicationName;
+		this.versionLabel = versionLabel;
+		this.s3Bucket = s3Bucket;
+		this.s3Key = s3Key;
+	}
+
+	@Override
+	public StepExecution start(StepContext stepContext) throws Exception {
+		return new Execution(this, stepContext);
+	}
+
+	@DataBoundSetter
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requiresDefault();
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "ebCreateApplicationVersion";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Creates a new version for an elastic beanstalk application";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+		private static final long serialVersionUID = 1L;
+		private final transient EBCreateApplicationVersionStep step;
+
+		protected Execution(EBCreateApplicationVersionStep step, @Nonnull StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			TaskListener listener = this.getContext().get(TaskListener.class);
+			AWSElasticBeanstalk client = AWSElasticBeanstalkClientBuilder.defaultClient();
+			listener.getLogger().format("Creating application version (%s) for application (%s) %n", step.versionLabel, step.applicationName);
+
+			CreateApplicationVersionRequest request = new CreateApplicationVersionRequest();
+			request.setApplicationName(step.applicationName);
+			request.setVersionLabel(step.versionLabel);
+			request.setSourceBundle(new S3Location(step.s3Bucket, step.s3Key));
+			request.setDescription(step.description);
+
+			CreateApplicationVersionResult result = client.createApplicationVersion(request);
+			listener.getLogger().format(
+					"Created a new version (%s) for the application (%s) with arn (%s) %n",
+					step.versionLabel,
+					step.applicationName,
+					result.getApplicationVersion().getApplicationVersionArn()
+			);
+
+			return null;
+		}
+	}
+}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateConfigurationTemplateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateConfigurationTemplateStep.java
@@ -1,0 +1,124 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.CreateConfigurationTemplateRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateConfigurationTemplateResult;
+import com.amazonaws.services.elasticbeanstalk.model.SourceConfiguration;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public class EBCreateConfigurationTemplateStep extends Step {
+	private final String applicationName;
+	private final String templateName;
+	private String environmentId;
+	private String solutionStackName;
+	private String sourceConfigurationApplication;
+	private String sourceConfigurationTemplate;
+	private String description;
+
+	@DataBoundConstructor
+	public EBCreateConfigurationTemplateStep(String applicationName, String templateName) {
+		this.applicationName = applicationName;
+		this.templateName = templateName;
+	}
+
+	@Override
+	public StepExecution start(StepContext stepContext) throws Exception {
+		return new Execution(this, stepContext);
+	}
+
+	@DataBoundSetter
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@DataBoundSetter
+	public void setEnvironmentId(String environmentId) {
+		this.environmentId = environmentId;
+	}
+
+	@DataBoundSetter
+	public void setSolutionStackName(String solutionStackName) {
+		this.solutionStackName = solutionStackName;
+	}
+
+	@DataBoundSetter
+	public void setSourceConfigurationApplication(String sourceConfigurationApplication) {
+		this.sourceConfigurationApplication = sourceConfigurationApplication;
+	}
+
+	@DataBoundSetter
+	public void setSourceConfigurationTemplate(String sourceConfigurationTemplate) {
+		this.sourceConfigurationTemplate = sourceConfigurationTemplate;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requiresDefault();
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "ebCreateConfigurationTemplate";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Creates a new configuration template for an elastic beanstalk application";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+		private static final long serialVersionUID = 1L;
+		private final transient EBCreateConfigurationTemplateStep step;
+
+		protected Execution(EBCreateConfigurationTemplateStep step, @Nonnull StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			TaskListener listener = this.getContext().get(TaskListener.class);
+			AWSElasticBeanstalk client = AWSElasticBeanstalkClientBuilder.defaultClient();
+			listener.getLogger().format("Creating configuration template (%s) for application (%s) %n", step.templateName, step.applicationName);
+
+			CreateConfigurationTemplateRequest request = new CreateConfigurationTemplateRequest();
+			request.setApplicationName(step.applicationName);
+			request.setTemplateName(step.templateName);
+			request.setEnvironmentId(step.environmentId);
+			request.setDescription(step.description);
+			request.setSolutionStackName(step.solutionStackName);
+
+			SourceConfiguration sourceConfiguration = new SourceConfiguration();
+			sourceConfiguration.setApplicationName(step.sourceConfigurationApplication);
+			sourceConfiguration.setTemplateName(step.sourceConfigurationTemplate);
+			request.setSourceConfiguration(sourceConfiguration);
+
+			CreateConfigurationTemplateResult result = client.createConfigurationTemplate(request);
+			listener.getLogger().format(
+					"Created a new configuration template (%s) for the application (%s) %n",
+					result.getTemplateName(),
+					result.getTemplateName()
+			);
+
+			return null;
+		}
+	}
+}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateEnvironmentStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateEnvironmentStep.java
@@ -1,0 +1,158 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.CreateEnvironmentRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateEnvironmentResult;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
+import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest;
+import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentResult;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+public class EBCreateEnvironmentStep extends Step {
+	private final String applicationName;
+	private final String environmentName;
+	private String description;
+	private String templateName;
+	private String solutionStackName;
+	private String versionLabel;
+	private boolean updateOnExisting = true;
+
+	@DataBoundConstructor
+	public EBCreateEnvironmentStep(String applicationName, String environmentName) {
+		this.applicationName = applicationName;
+		this.environmentName = environmentName;
+	}
+
+	@Override
+	public StepExecution start(StepContext stepContext) throws Exception {
+		return new Execution(this, stepContext);
+	}
+
+	@DataBoundSetter
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@DataBoundSetter
+	public void setTemplateName(String templateName) {
+		this.templateName = templateName;
+	}
+
+	@DataBoundSetter
+	public void setSolutionStackName(String solutionStackName) {
+		this.solutionStackName = solutionStackName;
+	}
+
+	@DataBoundSetter
+	public void setVersionLabel(String versionLabel) {
+		this.versionLabel = versionLabel;
+	}
+
+	@DataBoundSetter
+	public void setUpdateOnExisting(boolean updateOnExisting) {
+		this.updateOnExisting = updateOnExisting;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requiresDefault();
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "ebCreateEnvironment";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Creates a new Elastic Beanstalk environment";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+		private static final long serialVersionUID = 1L;
+		private final transient EBCreateEnvironmentStep step;
+
+		protected Execution(EBCreateEnvironmentStep step, @Nonnull StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			TaskListener listener = this.getContext().get(TaskListener.class);
+			AWSElasticBeanstalk client = AWSElasticBeanstalkClientBuilder.defaultClient();
+			listener.getLogger().format("Creating environment (%s) %n", step.environmentName);
+
+			boolean environmentExists = false;
+			if (step.updateOnExisting) {
+				DescribeEnvironmentsRequest describeRequest = new DescribeEnvironmentsRequest();
+				describeRequest.setApplicationName(step.applicationName);
+				describeRequest.setEnvironmentNames(Collections.singletonList(step.environmentName));
+				DescribeEnvironmentsResult result = client.describeEnvironments(describeRequest);
+				Optional<EnvironmentDescription> environment = result.getEnvironments().stream()
+						.filter(env -> !env.getStatus().equalsIgnoreCase("Terminated"))
+						.findFirst();
+				environmentExists = environment.isPresent();
+			}
+
+			if (environmentExists) {
+				UpdateEnvironmentRequest updateRequest = new UpdateEnvironmentRequest();
+				updateRequest.setApplicationName(step.applicationName);
+				updateRequest.setEnvironmentName(step.environmentName);
+				updateRequest.setDescription(step.description);
+				updateRequest.setTemplateName(step.templateName);
+				updateRequest.setVersionLabel(step.versionLabel);
+				updateRequest.setSolutionStackName(step.solutionStackName);
+				UpdateEnvironmentResult result = client.updateEnvironment(updateRequest);
+
+				listener.getLogger().format(
+						"Updated existing environment %s (%s) with arn (%s) %n",
+						result.getEnvironmentName(),
+						result.getEnvironmentId(),
+						result.getEnvironmentArn()
+				);
+				return null;
+			}
+
+			CreateEnvironmentRequest request = new CreateEnvironmentRequest();
+			request.setApplicationName(step.applicationName);
+			request.setEnvironmentName(step.environmentName);
+			request.setDescription(step.description);
+			request.setTemplateName(step.templateName);
+			request.setVersionLabel(step.versionLabel);
+			request.setSolutionStackName(step.solutionStackName);
+
+			CreateEnvironmentResult result = client.createEnvironment(request);
+			listener.getLogger().format(
+					"Created environment %s (%s) with arn (%s) %n",
+					result.getEnvironmentName(),
+					result.getEnvironmentId(),
+					result.getEnvironmentArn()
+			);
+
+			return null;
+		}
+	}
+}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStep.java
@@ -1,0 +1,112 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.SwapEnvironmentCNAMEsRequest;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public class EBSwapEnvironmentCNAMEsStep extends Step {
+	private String sourceEnvironmentId;
+	private String sourceEnvironmentName;
+	private String destinationEnvironmentId;
+	private String destinationEnvironmentName;
+
+	@DataBoundConstructor
+	public EBSwapEnvironmentCNAMEsStep() {
+	}
+
+	@Override
+	public StepExecution start(StepContext stepContext) throws Exception {
+		return new Execution(this, stepContext);
+	}
+
+	@DataBoundSetter
+	public void setSourceEnvironmentId(String sourceEnvironmentId) {
+		this.sourceEnvironmentId = sourceEnvironmentId;
+	}
+
+	@DataBoundSetter
+	public void setSourceEnvironmentName(String sourceEnvironmentName) {
+		this.sourceEnvironmentName = sourceEnvironmentName;
+	}
+
+	@DataBoundSetter
+	public void setDestinationEnvironmentId(String destinationEnvironmentId) {
+		this.destinationEnvironmentId = destinationEnvironmentId;
+	}
+
+	@DataBoundSetter
+	public void setDestinationEnvironmentName(String destinationEnvironmentName) {
+		this.destinationEnvironmentName = destinationEnvironmentName;
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requiresDefault();
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "ebSwapEnvironmentCNAMEs";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Swaps the CNAMEs of two elastic beanstalk environments.";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+		private static final long serialVersionUID = 1L;
+		private final transient EBSwapEnvironmentCNAMEsStep step;
+
+		protected Execution(EBSwapEnvironmentCNAMEsStep step, @Nonnull StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			TaskListener listener = this.getContext().get(TaskListener.class);
+			AWSElasticBeanstalk client = AWSElasticBeanstalkClientBuilder.defaultClient();
+			listener.getLogger().format("Swapping CNAMEs for environments %s(%s) and %s(%s) %n",
+					step.sourceEnvironmentName,
+					step.sourceEnvironmentId,
+					step.destinationEnvironmentName,
+					step.destinationEnvironmentId
+			);
+
+			SwapEnvironmentCNAMEsRequest request = new SwapEnvironmentCNAMEsRequest();
+			request.setSourceEnvironmentId(step.sourceEnvironmentId);
+			request.setSourceEnvironmentName(step.sourceEnvironmentName);
+			request.setDestinationEnvironmentId(step.destinationEnvironmentId);
+			request.setDestinationEnvironmentName(step.destinationEnvironmentName);
+
+			client.swapEnvironmentCNAMEs(request);
+			listener.getLogger().format("Swapped CNAMEs for environments %s(%s) and %s(%s) %n",
+					step.sourceEnvironmentName,
+					step.sourceEnvironmentId,
+					step.destinationEnvironmentName,
+					step.destinationEnvironmentId
+			);
+
+			return null;
+		}
+	}
+}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentHealthStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentHealthStep.java
@@ -1,0 +1,117 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.AWSElasticBeanstalkException;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+public class EBWaitOnEnvironmentHealthStep extends Step {
+	private final String applicationName;
+	private final String environmentName;
+	private String health = "Green";
+	private int stabilityThreshold = 60;
+
+	@DataBoundConstructor
+	public EBWaitOnEnvironmentHealthStep(String applicationName, String environmentName) {
+		this.applicationName = applicationName;
+		this.environmentName = environmentName;
+	}
+
+	@DataBoundSetter
+	public void setHealth(String health) {
+		this.health = health;
+	}
+
+	@DataBoundSetter
+	public void setStabilityThreshold(int stabilityThreshold) {
+		this.stabilityThreshold = stabilityThreshold;
+	}
+
+	@Override
+	public StepExecution start(StepContext stepContext) throws Exception {
+		return new Execution(this, stepContext);
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requiresDefault();
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "ebWaitOnEnvironmentHealth";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Waits until the specified environment application becomes available";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+		private static final long serialVersionUID = 1L;
+		private final transient EBWaitOnEnvironmentHealthStep step;
+
+		protected Execution(EBWaitOnEnvironmentHealthStep step, @Nonnull StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			TaskListener listener = this.getContext().get(TaskListener.class);
+			AWSElasticBeanstalk client = AWSElasticBeanstalkClientBuilder.defaultClient();
+			listener.getLogger().format("Waiting on environment %s health... %n", step.environmentName);
+
+			DescribeEnvironmentsRequest request = new DescribeEnvironmentsRequest();
+			request.setApplicationName(step.applicationName);
+			request.setEnvironmentNames(Collections.singletonList(step.environmentName));
+			long startTime = System.currentTimeMillis();
+			while (true) {
+				DescribeEnvironmentsResult result = client.describeEnvironments(request);
+
+				if (result.getEnvironments().isEmpty()) {
+					throw new AWSElasticBeanstalkException("Environment not found");
+				}
+
+				EnvironmentDescription environment = result.getEnvironments().get(0);
+				listener.getLogger().format(
+						"Environment Health: %s (%s) %n",
+						environment.getHealth(),
+						environment.getHealthStatus()
+				);
+
+				if (environment.getHealth().equalsIgnoreCase(step.health)) {
+					long stableFor = System.currentTimeMillis() - startTime;
+					if(stableFor > step.stabilityThreshold * 1000) {
+						return null;
+					}
+				} else {
+					startTime = System.currentTimeMillis();
+				}
+
+				Thread.sleep(10_000);
+			}
+		}
+	}
+}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentStatusStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentStatusStep.java
@@ -1,0 +1,101 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.AWSElasticBeanstalkException;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
+import de.taimos.pipeline.aws.utils.StepUtils;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+public class EBWaitOnEnvironmentStatusStep extends Step {
+	private final String applicationName;
+	private final String environmentName;
+	private String status = "Ready";
+
+	@DataBoundConstructor
+	public EBWaitOnEnvironmentStatusStep(String applicationName, String environmentName) {
+		this.applicationName = applicationName;
+		this.environmentName = environmentName;
+	}
+
+	@DataBoundSetter
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	@Override
+	public StepExecution start(StepContext stepContext) throws Exception {
+		return new Execution(this, stepContext);
+	}
+
+	@Extension
+	public static class DescriptorImpl extends StepDescriptor {
+
+		@Override
+		public Set<? extends Class<?>> getRequiredContext() {
+			return StepUtils.requiresDefault();
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "ebWaitOnEnvironmentStatus";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Waits until the specified environment becomes available";
+		}
+	}
+
+	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
+		private static final long serialVersionUID = 1L;
+		private final transient EBWaitOnEnvironmentStatusStep step;
+
+		protected Execution(EBWaitOnEnvironmentStatusStep step, @Nonnull StepContext context) {
+			super(context);
+			this.step = step;
+		}
+
+		@Override
+		protected Void run() throws Exception {
+			TaskListener listener = this.getContext().get(TaskListener.class);
+			AWSElasticBeanstalk client = AWSElasticBeanstalkClientBuilder.defaultClient();
+			listener.getLogger().format("Waiting on environment %s availability... %n", step.environmentName);
+
+			DescribeEnvironmentsRequest request = new DescribeEnvironmentsRequest();
+			request.setApplicationName(step.applicationName);
+			request.setEnvironmentNames(Collections.singletonList(step.environmentName));
+
+			while (true) {
+				DescribeEnvironmentsResult result = client.describeEnvironments(request);
+
+				if (result.getEnvironments().isEmpty()) {
+					throw new AWSElasticBeanstalkException("Environment not found");
+				}
+
+				EnvironmentDescription environment = result.getEnvironments().get(0);
+				listener.getLogger().format("Environment Status: %s %n", environment.getStatus());
+				if (environment.getStatus().equalsIgnoreCase(step.status)) {
+					return null;
+				}
+
+				Thread.sleep(10_000);
+			}
+		}
+	}
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBCreateApplicationStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBCreateApplicationStepTest.java
@@ -1,0 +1,53 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.ApplicationDescription;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationResult;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSElasticBeanstalkClientBuilder.class)
+public class EBCreateApplicationStepTest {
+    @Captor
+    ArgumentCaptor<CreateApplicationRequest> captor;
+
+    private static StepContext context;
+
+    @BeforeClass
+    public static void setupStepContext() throws Exception {
+        context = EBTestingUtils.setupStepContext();
+    }
+
+    @Test
+    public void stepDescriptorNameIsAsExpected() {
+        EBCreateApplicationStep.DescriptorImpl stepDescriptor = new EBCreateApplicationStep.DescriptorImpl();
+        Assert.assertEquals("ebCreateApplication", stepDescriptor.getFunctionName());
+    }
+
+    @Test
+    public void applicationIsCreatedWithNameProvided() throws Exception {
+        EBCreateApplicationStep step = new EBCreateApplicationStep("my application");
+        EBCreateApplicationStep.Execution execution = new EBCreateApplicationStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        CreateApplicationResult result = new CreateApplicationResult();
+        result.setApplication(new ApplicationDescription());
+        Mockito.when(client.createApplication(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).createApplication(captor.capture());
+        Assert.assertEquals("my application", captor.getValue().getApplicationName());
+    }
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBCreateApplicationVersionStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBCreateApplicationVersionStepTest.java
@@ -1,0 +1,61 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.ApplicationVersionDescription;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationVersionRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationVersionResult;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSElasticBeanstalkClientBuilder.class)
+public class EBCreateApplicationVersionStepTest {
+    @Captor
+    ArgumentCaptor<CreateApplicationVersionRequest> captor;
+
+    private static StepContext context;
+
+    @BeforeClass
+    public static void setupStepContext() throws Exception {
+        context = EBTestingUtils.setupStepContext();
+    }
+
+    @Test
+    public void stepDescriptorNameIsAsExpected() {
+        EBCreateApplicationVersionStep.DescriptorImpl stepDescriptor = new EBCreateApplicationVersionStep.DescriptorImpl();
+        Assert.assertEquals("ebCreateApplicationVersion", stepDescriptor.getFunctionName());
+    }
+
+    @Test
+    public void applicationVersionIsCreatedWithDetailsProvided() throws Exception {
+        EBCreateApplicationVersionStep step = new EBCreateApplicationVersionStep(
+                "my application",
+                "my version",
+                "s3-bucket",
+                "s3-key"
+        );
+        EBCreateApplicationVersionStep.Execution execution = new EBCreateApplicationVersionStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        CreateApplicationVersionResult result = new CreateApplicationVersionResult();
+        result.setApplicationVersion(new ApplicationVersionDescription());
+        Mockito.when(client.createApplicationVersion(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).createApplicationVersion(captor.capture());
+        Assert.assertEquals("my application", captor.getValue().getApplicationName());
+        Assert.assertEquals("my version", captor.getValue().getVersionLabel());
+        Assert.assertEquals("s3-bucket", captor.getValue().getSourceBundle().getS3Bucket());
+        Assert.assertEquals("s3-key", captor.getValue().getSourceBundle().getS3Key());
+    }
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBCreateConfigurationTemplateStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBCreateConfigurationTemplateStepTest.java
@@ -1,0 +1,62 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.CreateConfigurationTemplateRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateConfigurationTemplateResult;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSElasticBeanstalkClientBuilder.class)
+public class EBCreateConfigurationTemplateStepTest {
+    @Captor
+    ArgumentCaptor<CreateConfigurationTemplateRequest> captor;
+
+    private static StepContext context;
+
+    @BeforeClass
+    public static void setupStepContext() throws Exception {
+        context = EBTestingUtils.setupStepContext();
+    }
+
+    @Test
+    public void stepDescriptorNameIsAsExpected() {
+        EBCreateConfigurationTemplateStep.DescriptorImpl stepDescriptor = new EBCreateConfigurationTemplateStep.DescriptorImpl();
+        Assert.assertEquals("ebCreateConfigurationTemplate", stepDescriptor.getFunctionName());
+    }
+
+    @Test
+    public void templateIsCreatedWithDetailsProvided() throws Exception {
+        EBCreateConfigurationTemplateStep step = new EBCreateConfigurationTemplateStep("my application", "my-template");
+        step.setDescription("my-description");
+        step.setEnvironmentId("my-environment");
+        step.setSolutionStackName("my-solution-stack");
+        step.setSourceConfigurationApplication("my-source-configuration-app");
+        step.setSourceConfigurationTemplate("my-source-configuration-template");
+        EBCreateConfigurationTemplateStep.Execution execution = new EBCreateConfigurationTemplateStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        CreateConfigurationTemplateResult result = new CreateConfigurationTemplateResult();
+        Mockito.when(client.createConfigurationTemplate(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).createConfigurationTemplate(captor.capture());
+        Assert.assertEquals("my application", captor.getValue().getApplicationName());
+        Assert.assertEquals("my-template", captor.getValue().getTemplateName());
+        Assert.assertEquals("my-description", captor.getValue().getDescription());
+        Assert.assertEquals("my-environment", captor.getValue().getEnvironmentId());
+        Assert.assertEquals("my-solution-stack", captor.getValue().getSolutionStackName());
+        Assert.assertEquals("my-source-configuration-app", captor.getValue().getSourceConfiguration().getApplicationName());
+        Assert.assertEquals("my-source-configuration-template", captor.getValue().getSourceConfiguration().getTemplateName());
+    }
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBCreateEnvironmentStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBCreateEnvironmentStepTest.java
@@ -1,0 +1,156 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.CreateEnvironmentRequest;
+import com.amazonaws.services.elasticbeanstalk.model.CreateEnvironmentResult;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
+import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest;
+import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentResult;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSElasticBeanstalkClientBuilder.class)
+public class EBCreateEnvironmentStepTest {
+    @Captor
+    ArgumentCaptor<CreateEnvironmentRequest> captor;
+    @Captor
+    ArgumentCaptor<DescribeEnvironmentsRequest> describeCaptor;
+    @Captor
+    ArgumentCaptor<UpdateEnvironmentRequest> updateCaptor;
+
+    private static StepContext context;
+
+    @BeforeClass
+    public static void setupStepContext() throws Exception {
+        context = EBTestingUtils.setupStepContext();
+    }
+
+    @Test
+    public void stepDescriptorNameIsAsExpected() {
+        EBCreateEnvironmentStep.DescriptorImpl stepDescriptor = new EBCreateEnvironmentStep.DescriptorImpl();
+        Assert.assertEquals("ebCreateEnvironment", stepDescriptor.getFunctionName());
+    }
+
+    @Test
+    public void environmentIsCreatedWithDetailsProvided() throws Exception {
+        EBCreateEnvironmentStep step = new EBCreateEnvironmentStep("my application", "my-environment");
+        step.setDescription("my-description");
+        step.setTemplateName("my-template");
+        step.setSolutionStackName("my-solution-stack");
+        step.setVersionLabel("my-version");
+        step.setUpdateOnExisting(false);
+        EBCreateEnvironmentStep.Execution execution = new EBCreateEnvironmentStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        CreateEnvironmentResult result = new CreateEnvironmentResult();
+        Mockito.when(client.createEnvironment(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(0)).describeEnvironments(Mockito.any());
+        Mockito.verify(client, Mockito.times(0)).updateEnvironment(Mockito.any());
+        Mockito.verify(client, Mockito.times(1)).createEnvironment(captor.capture());
+        Assert.assertEquals("my application", captor.getValue().getApplicationName());
+        Assert.assertEquals("my-template", captor.getValue().getTemplateName());
+        Assert.assertEquals("my-description", captor.getValue().getDescription());
+        Assert.assertEquals("my-environment", captor.getValue().getEnvironmentName());
+        Assert.assertEquals("my-solution-stack", captor.getValue().getSolutionStackName());
+        Assert.assertEquals("my-version", captor.getValue().getVersionLabel());
+    }
+
+    @Test
+    public void environmentIsUpdatedIfExisting() throws Exception {
+        EBCreateEnvironmentStep step = new EBCreateEnvironmentStep("my application", "my-environment");
+        step.setDescription("my-description");
+        step.setTemplateName("my-template");
+        step.setSolutionStackName("my-solution-stack");
+        step.setVersionLabel("my-version");
+        EBCreateEnvironmentStep.Execution execution = new EBCreateEnvironmentStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        DescribeEnvironmentsResult describeResult = new DescribeEnvironmentsResult();
+        EnvironmentDescription environment = new EnvironmentDescription();
+        environment.setStatus("Ready");
+        describeResult.setEnvironments(Collections.singletonList(environment));
+        Mockito.when(client.describeEnvironments(Mockito.any())).thenReturn(describeResult);
+
+        UpdateEnvironmentResult updateResult = new UpdateEnvironmentResult();
+        Mockito.when(client.updateEnvironment(Mockito.any())).thenReturn(updateResult);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).describeEnvironments(describeCaptor.capture());
+        Mockito.verify(client, Mockito.times(1)).updateEnvironment(updateCaptor.capture());
+        Mockito.verify(client, Mockito.times(0)).createEnvironment(Mockito.any());
+        Assert.assertEquals("my application", updateCaptor.getValue().getApplicationName());
+        Assert.assertEquals("my-template", updateCaptor.getValue().getTemplateName());
+        Assert.assertEquals("my-description", updateCaptor.getValue().getDescription());
+        Assert.assertEquals("my-environment", updateCaptor.getValue().getEnvironmentName());
+        Assert.assertEquals("my-solution-stack", updateCaptor.getValue().getSolutionStackName());
+        Assert.assertEquals("my-version", updateCaptor.getValue().getVersionLabel());
+
+        Assert.assertEquals("my application", describeCaptor.getValue().getApplicationName());
+        Assert.assertEquals("my-environment", describeCaptor.getValue().getEnvironmentNames().get(0));
+    }
+
+    @Test
+    public void environmentIsCreatedIfNotExisting() throws Exception {
+        EBCreateEnvironmentStep step = new EBCreateEnvironmentStep("my application", "my-environment");
+        EBCreateEnvironmentStep.Execution execution = new EBCreateEnvironmentStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        DescribeEnvironmentsResult describeResult = new DescribeEnvironmentsResult();
+        Mockito.when(client.describeEnvironments(Mockito.any())).thenReturn(describeResult);
+
+        CreateEnvironmentResult result = new CreateEnvironmentResult();
+        Mockito.when(client.createEnvironment(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).describeEnvironments(describeCaptor.capture());
+        Mockito.verify(client, Mockito.times(0)).updateEnvironment(Mockito.any());
+        Mockito.verify(client, Mockito.times(1)).createEnvironment(Mockito.any());
+
+        Assert.assertEquals("my application", describeCaptor.getValue().getApplicationName());
+        Assert.assertEquals("my-environment", describeCaptor.getValue().getEnvironmentNames().get(0));
+    }
+
+    @Test
+    public void terminatedEnvironmentsAreNonExisting() throws Exception {
+        EBCreateEnvironmentStep step = new EBCreateEnvironmentStep("my application", "my-environment");
+        EBCreateEnvironmentStep.Execution execution = new EBCreateEnvironmentStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        DescribeEnvironmentsResult describeResult = new DescribeEnvironmentsResult();
+        EnvironmentDescription environment = new EnvironmentDescription();
+        environment.setStatus("Terminated");
+        describeResult.setEnvironments(Collections.singletonList(environment));
+        Mockito.when(client.describeEnvironments(Mockito.any())).thenReturn(describeResult);
+
+        CreateEnvironmentResult result = new CreateEnvironmentResult();
+        Mockito.when(client.createEnvironment(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).describeEnvironments(describeCaptor.capture());
+        Mockito.verify(client, Mockito.times(0)).updateEnvironment(Mockito.any());
+        Mockito.verify(client, Mockito.times(1)).createEnvironment(Mockito.any());
+
+        Assert.assertEquals("my application", describeCaptor.getValue().getApplicationName());
+        Assert.assertEquals("my-environment", describeCaptor.getValue().getEnvironmentNames().get(0));
+    }
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStepTest.java
@@ -1,0 +1,54 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.SwapEnvironmentCNAMEsRequest;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSElasticBeanstalkClientBuilder.class)
+public class EBSwapEnvironmentCNAMEsStepTest {
+    @Captor
+    ArgumentCaptor<SwapEnvironmentCNAMEsRequest> captor;
+
+    private static StepContext context;
+
+    @BeforeClass
+    public static void setupStepContext() throws Exception {
+        context = EBTestingUtils.setupStepContext();
+    }
+
+    @Test
+    public void stepDescriptorNameIsAsExpected() {
+        EBSwapEnvironmentCNAMEsStep.DescriptorImpl stepDescriptor = new EBSwapEnvironmentCNAMEsStep.DescriptorImpl();
+        Assert.assertEquals("ebSwapEnvironmentCNAMEs", stepDescriptor.getFunctionName());
+    }
+
+    @Test
+    public void swapIsDoneWithDetailsProvided() throws Exception {
+        EBSwapEnvironmentCNAMEsStep step = new EBSwapEnvironmentCNAMEsStep();
+        step.setSourceEnvironmentId("source-id");
+        step.setSourceEnvironmentName("source-name");
+        step.setDestinationEnvironmentId("destination-id");
+        step.setDestinationEnvironmentName("destination-name");
+        EBSwapEnvironmentCNAMEsStep.Execution execution = new EBSwapEnvironmentCNAMEsStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).swapEnvironmentCNAMEs(captor.capture());
+        Assert.assertEquals("source-id", captor.getValue().getSourceEnvironmentId());
+        Assert.assertEquals("source-name", captor.getValue().getSourceEnvironmentName());
+        Assert.assertEquals("destination-id", captor.getValue().getDestinationEnvironmentId());
+        Assert.assertEquals("destination-name", captor.getValue().getDestinationEnvironmentName());
+    }
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBTestingUtils.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBTestingUtils.java
@@ -1,0 +1,30 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.ApplicationDescription;
+import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationResult;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.io.PrintStream;
+
+class EBTestingUtils {
+
+    static StepContext setupStepContext() throws Exception {
+        StepContext context = Mockito.mock(StepContext.class);
+        TaskListener listener = Mockito.mock(TaskListener.class);
+        Mockito.when(listener.getLogger()).thenReturn(Mockito.mock(PrintStream.class));
+        Mockito.when(context.get(Mockito.any())).thenReturn(listener);
+        return context;
+    }
+
+    static AWSElasticBeanstalk setupElasticBeanstalkClient() {
+        PowerMockito.mockStatic(AWSElasticBeanstalkClientBuilder.class);
+        AWSElasticBeanstalk client = Mockito.mock(AWSElasticBeanstalk.class);
+        PowerMockito.when(AWSElasticBeanstalkClientBuilder.defaultClient()).thenReturn(client);
+        return client;
+    }
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentHealthStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentHealthStepTest.java
@@ -1,0 +1,59 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSElasticBeanstalkClientBuilder.class)
+public class EBWaitOnEnvironmentHealthStepTest {
+    @Captor
+    ArgumentCaptor<DescribeEnvironmentsRequest> describeCaptor;
+
+    private static StepContext context;
+
+    @BeforeClass
+    public static void setupStepContext() throws Exception {
+        context = EBTestingUtils.setupStepContext();
+    }
+
+    @Test
+    public void stepDescriptorNameIsAsExpected() {
+        EBWaitOnEnvironmentHealthStep.DescriptorImpl stepDescriptor = new EBWaitOnEnvironmentHealthStep.DescriptorImpl();
+        Assert.assertEquals("ebWaitOnEnvironmentHealth", stepDescriptor.getFunctionName());
+    }
+
+    @Test
+    public void waitStopImmediatelyAfterFindingGreenHealthForNoThreshold() throws Exception {
+        EBWaitOnEnvironmentHealthStep step = new EBWaitOnEnvironmentHealthStep("my application", "my-environment");
+        step.setStabilityThreshold(0);
+        EBWaitOnEnvironmentHealthStep.Execution execution = new EBWaitOnEnvironmentHealthStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        DescribeEnvironmentsResult result = new DescribeEnvironmentsResult();
+        EnvironmentDescription environment = new EnvironmentDescription();
+        environment.setHealth("Green");
+        result.setEnvironments(Collections.singletonList(environment));
+        Mockito.when(client.describeEnvironments(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.atMost(2)).describeEnvironments(describeCaptor.capture());
+        Assert.assertEquals("my application", describeCaptor.getValue().getApplicationName());
+        Assert.assertEquals("my-environment", describeCaptor.getValue().getEnvironmentNames().get(0));
+    }
+}

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentStatusStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentStatusStepTest.java
@@ -1,0 +1,58 @@
+package de.taimos.pipeline.aws.eb;
+
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSElasticBeanstalkClientBuilder.class)
+public class EBWaitOnEnvironmentStatusStepTest {
+    @Captor
+    ArgumentCaptor<DescribeEnvironmentsRequest> describeCaptor;
+
+    private static StepContext context;
+
+    @BeforeClass
+    public static void setupStepContext() throws Exception {
+        context = EBTestingUtils.setupStepContext();
+    }
+
+    @Test
+    public void stepDescriptorNameIsAsExpected() {
+        EBWaitOnEnvironmentStatusStep.DescriptorImpl stepDescriptor = new EBWaitOnEnvironmentStatusStep.DescriptorImpl();
+        Assert.assertEquals("ebWaitOnEnvironmentStatus", stepDescriptor.getFunctionName());
+    }
+
+    @Test
+    public void waitStopImmediatelyAfterFindingReadyStatus() throws Exception {
+        EBWaitOnEnvironmentStatusStep step = new EBWaitOnEnvironmentStatusStep("my application", "my-environment");
+        EBWaitOnEnvironmentStatusStep.Execution execution = new EBWaitOnEnvironmentStatusStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        DescribeEnvironmentsResult result = new DescribeEnvironmentsResult();
+        EnvironmentDescription environment = new EnvironmentDescription();
+        environment.setStatus("Ready");
+        result.setEnvironments(Collections.singletonList(environment));
+        Mockito.when(client.describeEnvironments(Mockito.any())).thenReturn(result);
+
+        execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).describeEnvironments(describeCaptor.capture());
+        Assert.assertEquals("my application", describeCaptor.getValue().getApplicationName());
+        Assert.assertEquals("my-environment", describeCaptor.getValue().getEnvironmentNames().get(0));
+    }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds support for the most common AWS Elastic Beanstalk commands that allow the creation and update of elastic beanstalk applications


* **What is the current behavior?** (You can also link to an open issue here)
Not implemented. Requested in #65 


* **What is the new behavior (if this is a feature change)?**
Add the following commands:
 * ebCreateApplication - Create a new elastic beanstalk application
 * ebCreateApplicationVersion - Create a new elastic beanstalk deploy-able application version
 * ebCreateConfigurationTemplate - Create a new configuration template to use as a basis for a new environment configuration
 * ebCreateEnvironment - Create a new elastic beanstalk application environment
 * ebSwapEnvironmentCNAMEs - Swap the CNAMEs of 2 elastic beanstalk application environments
 * ebWaitOnEnvironmentStatus - Wait for the environment to be ready to receive additional commands 
 * ebWaitOnEnvironmentHealth - Wait for application environment health to be stable


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No, all commands are new and do not affect previous steps


* **Other information**: