### PR TITLE
Add setting that enables fetching credentials from node

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ withAWS(role: 'myRole', roleAccount: '123456789', principalArn: 'arn:aws:iam::12
 }
 ```
 
+Authentication by retrieving credentials from the node in scope
+
+```groovy
+node('myNode') { // Credentials will be fetched from this node
+  withAWS(role: 'myRole', roleAccount: '123456789', region:'eu-west-1', fromNode: true) {
+    // do something
+  }
+}
+```
+
 When you use Jenkins Declarative Pipelines you can also use `withAWS` in an options block:
 
 ```groovy

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Authentication by retrieving credentials from the node in scope
 
 ```groovy
 node('myNode') { // Credentials will be fetched from this node
-  withAWS(role: 'myRole', roleAccount: '123456789', region:'eu-west-1', fromNode: true) {
+  withAWS(role: 'myRole', roleAccount: '123456789', region:'eu-west-1', useNode: true) {
     // do something
   }
 }

--- a/README.md
+++ b/README.md
@@ -54,10 +54,15 @@ This plugins adds Jenkins pipeline steps to interact with the AWS API.
 
 # Primary/Agent setups
 
-This plugin is not optimized to setups with a primary and multiple agents. 
+This plugin is not optimized to setups with a primary and multiple agents.
 Only steps that touch the workspace are executed on the agents while the rest is executed on the master.
 
 For the best experience make sure that primary and agents have the same IAM permission and networking capabilities.
+
+## Retrieve credentials from node
+
+By default, credentials lookup is done on the master node for all steps.
+To enable credentials lookup on the current node, enable `Retrieve credentials from node` in Jenkins global configuration.
 
 # Usage / Steps
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For the best experience make sure that primary and agents have the same IAM perm
 ## Retrieve credentials from node
 
 By default, credentials lookup is done on the master node for all steps.
-To enable credentials lookup on the current node, enable `Retrieve credentials from node` in Jenkins global configuration.
+To enable credentials lookup on the current node, enable `Retrieve credentials from node` in Jenkins global configuration. This is globally applicable and restricts all access to the master's credentials.
 
 # Usage / Steps
 

--- a/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
@@ -20,10 +20,6 @@
  */
 package de.taimos.pipeline.aws;
 
-import com.amazonaws.retry.RetryPolicy;
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.workflow.steps.StepContext;
-
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -35,10 +31,21 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.client.builder.AwsSyncClientBuilder;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
+import com.amazonaws.retry.RetryPolicy;
 
 import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.TaskListener;
 
-public class AWSClientFactory {
+import java.io.Serializable;
+import java.io.IOException;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+
+public class AWSClientFactory implements Serializable {
 
 	static final String AWS_PROFILE = "AWS_PROFILE";
 	static final String AWS_DEFAULT_PROFILE = "AWS_DEFAULT_PROFILE";
@@ -55,17 +62,21 @@ public class AWSClientFactory {
 
 	public static <B extends AwsSyncClientBuilder<?, T>, T> T create(B clientBuilder, StepContext context) {
 		try {
-			return configureBuilder(clientBuilder, context.get(EnvVars.class)).build();
+			return configureBuilder(clientBuilder, context, context.get(EnvVars.class)).build();
 		} catch (Exception e) {
 			throw new IllegalArgumentException(e);
 		}
 	}
 
-	public static <B extends AwsSyncClientBuilder<?, T>, T> T create(B clientBuilder, EnvVars vars) {
-		return configureBuilder(clientBuilder, vars).build();
+	public static <B extends AwsSyncClientBuilder<?, T>, T> T create(B clientBuilder, StepContext context, EnvVars vars) {
+		return configureBuilder(clientBuilder, context, vars).build();
 	}
 
-	public static <B extends AwsSyncClientBuilder<?, ?>> B configureBuilder(final B clientBuilder, final EnvVars vars) {
+	public static <B extends AwsSyncClientBuilder<?, T>, T> T create(B clientBuilder, EnvVars vars) {
+		return configureBuilder(clientBuilder, null, vars).build();
+	}
+
+	public static <B extends AwsSyncClientBuilder<?, ?>> B configureBuilder(final B clientBuilder, StepContext context, final EnvVars vars) {
 		if (clientBuilder == null) {
 			throw new IllegalArgumentException("ClientBuilder must not be null");
 		}
@@ -74,7 +85,9 @@ public class AWSClientFactory {
 		} else {
 			clientBuilder.setRegion(AWSClientFactory.getRegion(vars).getName());
 		}
-		clientBuilder.setCredentials(AWSClientFactory.getCredentials(vars));
+
+		clientBuilder.setCredentials(AWSClientFactory.getCredentials(vars, context));
+
 		clientBuilder.setClientConfiguration(AWSClientFactory.getClientConfiguration(vars));
 		return clientBuilder;
 	}
@@ -87,7 +100,7 @@ public class AWSClientFactory {
 		return clientConfiguration;
 	}
 
-	private static AWSCredentialsProvider getCredentials(EnvVars vars) {
+	private static AWSCredentialsProvider getCredentials(EnvVars vars, StepContext context) {
 		AWSCredentialsProvider provider = handleStaticCredentials(vars);
 		if (provider != null) {
 			return provider;
@@ -98,7 +111,22 @@ public class AWSClientFactory {
 			return provider;
 		}
 
+		if (PluginImpl.getInstance().isEnableCredentialsFromNode() && context != null) {
+			try {
+				return AWSClientFactory.getCredentialsFromNode(context, vars);
+			} catch (Exception e) {
+				throw new RuntimeException("Unable to retrieve credentials from node.");
+			}
+		}
+
 		return new DefaultAWSCredentialsProviderChain();
+	}
+
+	private static AWSCredentialsProvider getCredentialsFromNode(StepContext context, EnvVars envVars) throws IOException, InterruptedException {
+		FilePath ws = context.get(FilePath.class);
+		TaskListener listener = context.get(TaskListener.class);
+		SerializableAWSCredentialsProvider serializableAWSCredentialsProvider = ws.act(new AWSCredentialsProviderCallable(listener));
+		return serializableAWSCredentialsProvider;
 	}
 
 	private static AWSCredentialsProvider handleProfile(EnvVars vars) {
@@ -141,4 +169,6 @@ public class AWSClientFactory {
 		}
 		return Region.getRegion(Regions.DEFAULT_REGION);
 	}
+
+	private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
@@ -55,6 +55,8 @@ public class AWSClientFactory implements Serializable {
 	static final String AWS_DEFAULT_REGION = "AWS_DEFAULT_REGION";
 	static final String AWS_REGION = "AWS_REGION";
 	static final String AWS_ENDPOINT_URL = "AWS_ENDPOINT_URL";
+	static final String AWS_PIPELINE_STEPS_FROM_NODE = "AWS_PIPELINE_STEPS_FROM_NODE";
+
 
 	private AWSClientFactory() {
 		//
@@ -111,11 +113,13 @@ public class AWSClientFactory implements Serializable {
 			return provider;
 		}
 
-		if (PluginImpl.getInstance().isEnableCredentialsFromNode() && context != null) {
-			try {
-				return AWSClientFactory.getCredentialsFromNode(context, vars);
-			} catch (Exception e) {
-				throw new RuntimeException("Unable to retrieve credentials from node.");
+		if (context != null) {
+			if (PluginImpl.getInstance().isEnableCredentialsFromNode() || Boolean.valueOf(vars.get(AWS_PIPELINE_STEPS_FROM_NODE))) {
+				try {
+					return AWSClientFactory.getCredentialsFromNode(context, vars);
+				} catch (Exception e) {
+					throw new RuntimeException("Unable to retrieve credentials from node.");
+				}
 			}
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/AWSCredentialsProviderCallable.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSCredentialsProviderCallable.java
@@ -1,0 +1,56 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2016 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.taimos.pipeline.aws;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+
+import hudson.model.TaskListener;
+import hudson.remoting.VirtualChannel;
+
+import jenkins.MasterToSlaveFileCallable;
+
+import java.io.File;
+import java.io.IOException;
+
+/*
+ * Use the FilePath abstraction to execute code on the remote node
+ * https://wiki.jenkins.io/display/JENKINS/Making+your+plugin+behave+in+distributed+Jenkins
+ *
+ */
+public class AWSCredentialsProviderCallable extends MasterToSlaveFileCallable<SerializableAWSCredentialsProvider> {
+
+	private final TaskListener listener;
+
+	public AWSCredentialsProviderCallable(TaskListener listener) {
+		this.listener = listener;
+	}
+
+	@Override
+	public SerializableAWSCredentialsProvider invoke(File f, VirtualChannel vc) throws IOException, InterruptedException {
+		AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
+		listener.getLogger().println("Retrieving credentials from node.");
+		return new SerializableAWSCredentialsProvider(provider);
+	}
+
+	private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/de/taimos/pipeline/aws/PluginImpl.java
+++ b/src/main/java/de/taimos/pipeline/aws/PluginImpl.java
@@ -1,0 +1,90 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2016 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.taimos.pipeline.aws;
+
+import hudson.Extension;
+import hudson.ExtensionList;
+import static hudson.model.Descriptor.FormException;
+import jenkins.model.GlobalConfiguration;
+
+import javax.annotation.Nonnull;
+
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+
+/**
+* Global configuration
+*/
+@Extension
+public class PluginImpl extends GlobalConfiguration {
+
+	private boolean enableCredentialsFromNode;
+
+	/**
+	 * Default constructor.
+	 */
+	@DataBoundConstructor
+	public PluginImpl() {
+		load();
+	}
+
+	@Override
+	public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+		json = json.getJSONObject("enableCredentialsFromNode");
+		enableCredentialsFromNode = json.getBoolean("enableCredentialsFromNode");
+		save();
+		return true;
+	}
+
+	/**
+	 * Whether or not to retrieve credentials from the node. Defaults to using the master's instance profile.
+	 * @return True if enabled.
+	 */
+	public boolean isEnableCredentialsFromNode() {
+		return this.enableCredentialsFromNode;
+	}
+
+	/**
+	 * Return the singleton instance.
+	 *
+	 * @return the one.
+	 */
+	@Nonnull
+	public static PluginImpl getInstance() {
+		return ExtensionList.lookup(PluginImpl.class).get(0);
+	}
+
+	/**
+	 * Set enableCredentialsFromNode
+	 * Default value is false.
+	 *
+	 * @param enableCredentialsFromNode whether to retrieve credentials from node or from master
+	 */
+	@DataBoundSetter
+	public void setEnableCredentialsFromNode(boolean enableCredentialsFromNode) {
+		this.enableCredentialsFromNode = enableCredentialsFromNode;
+	}
+
+}

--- a/src/main/java/de/taimos/pipeline/aws/S3CopyStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3CopyStep.java
@@ -260,7 +260,7 @@ public class S3CopyStep extends AbstractS3Step {
 			}
 
 			TransferManager mgr = TransferManagerBuilder.standard()
-					.withS3Client(AWSClientFactory.create(s3ClientOptions.createAmazonS3ClientBuilder(), envVars))
+					.withS3Client(AWSClientFactory.create(s3ClientOptions.createAmazonS3ClientBuilder(), this.getContext(), envVars))
 					.build();
 			try {
 				final Copy copy = mgr.copy(request);

--- a/src/main/java/de/taimos/pipeline/aws/S3PresignUrlStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3PresignUrlStep.java
@@ -124,7 +124,7 @@ public class S3PresignUrlStep extends AbstractS3Step {
 			Preconditions.checkArgument(key != null && !key.isEmpty(), "Key must not be null or empty");
 
 			EnvVars envVars = this.getContext().get(EnvVars.class);
-			AmazonS3 s3 = AWSClientFactory.create(this.step.createS3ClientOptions().createAmazonS3ClientBuilder(), envVars);
+			AmazonS3 s3 = AWSClientFactory.create(this.step.createS3ClientOptions().createAmazonS3ClientBuilder(), this.getContext(), envVars);
 			Date expiration = DateTime.now().plusSeconds(this.step.getDurationInSeconds()).toDate();
 			URL url = s3.generatePresignedUrl(bucket, key, expiration, this.step.getHttpMethod());
 			return url.toString();

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -377,7 +377,7 @@ public class S3UploadStep extends AbstractS3Step {
 				EnvVars envVars = Execution.this.getContext().get(EnvVars.class);
 
 				TransferManager mgr = TransferManagerBuilder.standard()
-						.withS3Client(AWSClientFactory.create(amazonS3ClientOptions.createAmazonS3ClientBuilder(), envVars))
+						.withS3Client(AWSClientFactory.create(amazonS3ClientOptions.createAmazonS3ClientBuilder(), Execution.this.getContext(), envVars))
 						.build();
 
 				byte[] bytes = text.getBytes(Charset.forName("UTF-8"));

--- a/src/main/java/de/taimos/pipeline/aws/SerializableAWSCredentialsProvider.java
+++ b/src/main/java/de/taimos/pipeline/aws/SerializableAWSCredentialsProvider.java
@@ -1,0 +1,65 @@
+/*
+ * -
+ * #%L
+ * Pipeline: AWS Steps
+ * %%
+ * Copyright (C) 2016 Taimos GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package de.taimos.pipeline.aws;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.STSSessionCredentials;
+
+import java.io.Serializable;
+
+/*
+ * Serialize credentials so that they can be passed back to master
+ *
+ */
+public class SerializableAWSCredentialsProvider implements AWSCredentialsProvider, Serializable {
+	private String accessKey;
+	private String secretAccessKey;
+	private String sessionToken;
+
+	SerializableAWSCredentialsProvider(AWSCredentialsProvider credentialsProvider) {
+		AWSCredentials credentials = credentialsProvider.getCredentials();
+		this.accessKey = credentials.getAWSAccessKeyId();
+		this.secretAccessKey = credentials.getAWSSecretKey();
+		// A token may be required, so check class
+		if (credentials.getClass() == BasicSessionCredentials.class) {
+			BasicSessionCredentials castedCredentials = (BasicSessionCredentials) credentials;
+			this.sessionToken = castedCredentials.getSessionToken();
+		}
+		if (credentials.getClass() == STSSessionCredentials.class) {
+			STSSessionCredentials castedCredentials = (STSSessionCredentials) credentials;
+			this.sessionToken = castedCredentials.getSessionToken();
+		}
+	}
+
+	public AWSCredentials getCredentials() {
+		if (this.sessionToken != null) {
+			return new BasicSessionCredentials(this.accessKey, this.secretAccessKey, this.sessionToken);
+		}
+		return new BasicAWSCredentials(this.accessKey, this.secretAccessKey);
+	}
+
+	public void refresh() {}
+
+	private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -82,6 +82,7 @@ public class WithAWSStep extends Step {
 	private String roleSessionName;
 	private String principalArn = "";
 	private String samlAssertion = "";
+	private boolean fromNode = false;
 
 	@DataBoundConstructor
 	public WithAWSStep() {
@@ -214,6 +215,15 @@ public class WithAWSStep extends Step {
 		this.samlAssertion = samlAssertion;
 	}
 
+	public boolean getFromNode() {
+		return this.fromNode;
+	}
+
+	@DataBoundSetter
+	public void setFromNode(final boolean fromNode) {
+		this.fromNode = fromNode;
+	}
+
 	@Override
 	public StepExecution start(StepContext context) throws Exception {
 		return new WithAWSStep.Execution(this, context);
@@ -279,6 +289,7 @@ public class WithAWSStep extends Step {
 			this.step = step;
 			try {
 				this.envVars = context.get(EnvVars.class);
+				this.envVars.put(AWSClientFactory.AWS_PIPELINE_STEPS_FROM_NODE, String.valueOf(this.step.getFromNode()));
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}
@@ -380,7 +391,7 @@ public class WithAWSStep extends Step {
 				assumeRole.withSamlAssertion(this.step.getSamlAssertion(), this.step.getPrincipalArn());
 				assumeRole.withSessionName(this.createRoleSessionName());
 
-				this.getContext().get(TaskListener.class).getLogger().format("Requesting assume role");
+				this.getContext().get(TaskListener.class).getLogger().format("Requesting assume role\n");
 				this.getContext().get(TaskListener.class).getLogger().format("Assuming role ARN is %s", assumeRole.toString());
 				AssumedRole assumedRole = assumeRole.assumedRole(sts);
 				this.getContext().get(TaskListener.class).getLogger().format("Assumed role %s with id %s %n ", assumedRole.getAssumedRoleUser().getArn(), assumedRole.getAssumedRoleUser().getAssumedRoleId());

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -295,6 +295,7 @@ public class WithAWSStep extends Step {
 			this.withFederatedUserId(awsEnv);
 
 			EnvironmentExpander expander = new EnvironmentExpander() {
+				private static final long serialVersionUID = 1L;
 				@Override
 				public void expand(@Nonnull EnvVars envVars) {
 					envVars.overrideAll(awsEnv);
@@ -312,7 +313,7 @@ public class WithAWSStep extends Step {
 
 		private void withFederatedUserId(@Nonnull EnvVars localEnv) {
 			if (!StringUtils.isNullOrEmpty(this.step.getFederatedUserId())) {
-				AWSSecurityTokenService sts = AWSClientFactory.create(AWSSecurityTokenServiceClientBuilder.standard(), this.envVars);
+				AWSSecurityTokenService sts = AWSClientFactory.create(AWSSecurityTokenServiceClientBuilder.standard(), this.getContext(), this.envVars);
 				GetFederationTokenRequest getFederationTokenRequest = new GetFederationTokenRequest();
 				getFederationTokenRequest.setDurationSeconds(this.step.getDuration());
 				getFederationTokenRequest.setName(this.step.getFederatedUserId());
@@ -368,8 +369,8 @@ public class WithAWSStep extends Step {
 
 		private void withRole(@Nonnull EnvVars localEnv) throws IOException, InterruptedException {
 			if (!StringUtils.isNullOrEmpty(this.step.getRole())) {
-				
-				AWSSecurityTokenService sts = AWSClientFactory.create(AWSSecurityTokenServiceClientBuilder.standard(), this.envVars);
+
+				AWSSecurityTokenService sts = AWSClientFactory.create(AWSSecurityTokenServiceClientBuilder.standard(), this.getContext(), this.envVars);
 
 				AssumeRole assumeRole = IamRoleUtils.validRoleArn(this.step.getRole()) ? new AssumeRole(this.step.getRole()) :
 						new AssumeRole(this.step.getRole(), this.createAccountId(sts), IamRoleUtils.selectPartitionName(this.step.getRegion()));

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -391,7 +391,7 @@ public class WithAWSStep extends Step {
 				assumeRole.withSamlAssertion(this.step.getSamlAssertion(), this.step.getPrincipalArn());
 				assumeRole.withSessionName(this.createRoleSessionName());
 
-				this.getContext().get(TaskListener.class).getLogger().format("Requesting assume role\n");
+				this.getContext().get(TaskListener.class).getLogger().format("Requesting assume role%n");
 				this.getContext().get(TaskListener.class).getLogger().format("Assuming role ARN is %s", assumeRole.toString());
 				AssumedRole assumedRole = assumeRole.assumedRole(sts);
 				this.getContext().get(TaskListener.class).getLogger().format("Assumed role %s with id %s %n ", assumedRole.getAssumedRoleUser().getArn(), assumedRole.getAssumedRoleUser().getAssumedRoleId());

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -82,7 +82,7 @@ public class WithAWSStep extends Step {
 	private String roleSessionName;
 	private String principalArn = "";
 	private String samlAssertion = "";
-	private boolean fromNode = false;
+	private boolean useNode = false;
 
 	@DataBoundConstructor
 	public WithAWSStep() {
@@ -215,13 +215,13 @@ public class WithAWSStep extends Step {
 		this.samlAssertion = samlAssertion;
 	}
 
-	public boolean getFromNode() {
-		return this.fromNode;
+	public boolean getUseNode() {
+		return this.useNode;
 	}
 
 	@DataBoundSetter
-	public void setFromNode(final boolean fromNode) {
-		this.fromNode = fromNode;
+	public void setUseNode(final boolean useNode) {
+		this.useNode = useNode;
 	}
 
 	@Override
@@ -289,7 +289,7 @@ public class WithAWSStep extends Step {
 			this.step = step;
 			try {
 				this.envVars = context.get(EnvVars.class);
-				this.envVars.put(AWSClientFactory.AWS_PIPELINE_STEPS_FROM_NODE, String.valueOf(this.step.getFromNode()));
+				this.envVars.put(AWSClientFactory.AWS_PIPELINE_STEPS_FROM_NODE, String.valueOf(this.step.getUseNode()));
 			} catch (Exception e) {
 				throw new IllegalStateException(e);
 			}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
@@ -120,7 +120,7 @@ abstract class AbstractCFNCreateStep extends TemplateStepBase {
 
 			this.checkPreconditions();
 
-			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), Execution.this.getEnvVars());
+			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), Execution.this.getContext(), Execution.this.getEnvVars());
 			CloudFormationStack cfnStack = new CloudFormationStack(client, stack, Execution.this.getListener());
 			if (cfnStack.exists()) {
 				Collection<Parameter> parameters = ParameterParser.parseWithKeepParams(Execution.this.getWorkspace(), Execution.this.getStep());
@@ -135,7 +135,7 @@ abstract class AbstractCFNCreateStep extends TemplateStepBase {
 		}
 
 		protected CloudFormationStack getCfnStack() {
-			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), this.getEnvVars());
+			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), this.getContext(), this.getEnvVars());
 			return new CloudFormationStack(client, this.getStack(), this.getListener());
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/AbstractCFNCreateStackSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/AbstractCFNCreateStackSetStep.java
@@ -120,7 +120,7 @@ abstract class AbstractCFNCreateStackSetStep extends TemplateStepBase {
 
 			this.checkPreconditions();
 
-			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), Execution.this.getEnvVars());
+			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), Execution.this.getContext(), Execution.this.getEnvVars());
 			CloudFormationStackSet cfnStackSet = new CloudFormationStackSet(client, stackSet, Execution.this.getListener(), SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY);
 			if (cfnStackSet.exists()) {
 				Collection<Parameter> parameters = ParameterParser.parseWithKeepParams(getWorkspace(), getStep());
@@ -135,7 +135,7 @@ abstract class AbstractCFNCreateStackSetStep extends TemplateStepBase {
 		}
 
 		protected CloudFormationStackSet getCfnStackSet() {
-			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), this.getEnvVars());
+			AmazonCloudFormation client = AWSClientFactory.create(AmazonCloudFormationClientBuilder.standard(), this.getContext(), this.getEnvVars());
 			return new CloudFormationStackSet(client, this.getStackSet(), this.getListener(), SleepStrategy.EXPONENTIAL_BACKOFF_STRATEGY);
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/elb/ELBDeregisterInstanceStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/elb/ELBDeregisterInstanceStep.java
@@ -127,16 +127,16 @@ public class ELBDeregisterInstanceStep extends Step {
 			ArrayList<TargetDescription> arr = new ArrayList<TargetDescription>();
 			arr.add(new TargetDescription().withId(this.step.instanceID).withPort(this.step.port));
 			DeregisterTargetsRequest request = new DeregisterTargetsRequest().withTargetGroupArn(this.step.targetGroupARN).withTargets( arr );
-			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getEnvVars());
+			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getContext(), this.getEnvVars());
 			client.deregisterTargets(request);
-			
+
 			DescribeTargetHealthRequest req = new DescribeTargetHealthRequest().withTargetGroupArn(this.step.targetGroupARN);
 			DescribeTargetHealthResult res = client.describeTargetHealth(req);
 			listener.getLogger().println(res.toString());
-			
+
 			return null;
 		}
-		
+
 		public EnvVars getEnvVars() {
 			try {
 				return this.getContext().get(EnvVars.class);

--- a/src/main/java/de/taimos/pipeline/aws/elb/ELBIsInstanceDeregisteredStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/elb/ELBIsInstanceDeregisteredStep.java
@@ -118,9 +118,9 @@ public class ELBIsInstanceDeregisteredStep extends Step {
 		protected Boolean run() throws Exception {
 			TaskListener listener = this.getContext().get(TaskListener.class);
 			listener.getLogger().println("elbIsInstanceDeregistered instanceID: " + this.step.instanceID + " port: " + this.step.port + " from targetGroupARN: " + this.step.targetGroupARN);
-			
+
 			Boolean rval = true;
-			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getEnvVars());
+			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getContext(), this.getEnvVars());
 			DescribeTargetHealthRequest req = new DescribeTargetHealthRequest().withTargetGroupArn(this.step.targetGroupARN);
 			DescribeTargetHealthResult res = client.describeTargetHealth(req);
 			List<TargetHealthDescription> targets = res.getTargetHealthDescriptions();
@@ -131,10 +131,10 @@ public class ELBIsInstanceDeregisteredStep extends Step {
 				}
 			}
 			listener.getLogger().println(res.toString());
-			
+
 			return rval;
 		}
-		
+
 		public EnvVars getEnvVars() {
 			try {
 				return this.getContext().get(EnvVars.class);

--- a/src/main/java/de/taimos/pipeline/aws/elb/ELBIsInstanceRegisteredStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/elb/ELBIsInstanceRegisteredStep.java
@@ -118,9 +118,9 @@ public class ELBIsInstanceRegisteredStep extends Step {
 		protected Boolean run() throws Exception {
 			TaskListener listener = this.getContext().get(TaskListener.class);
 			listener.getLogger().println("elbIsInstanceRegistered instanceID: " + this.step.instanceID + " port: " + this.step.port + " from targetGroupARN: " + this.step.targetGroupARN);
-			
+
 			Boolean rval = false;
-			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getEnvVars());
+			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getContext(), this.getEnvVars());
 			DescribeTargetHealthRequest req = new DescribeTargetHealthRequest().withTargetGroupArn(this.step.targetGroupARN);
 			DescribeTargetHealthResult res = client.describeTargetHealth(req);
 			List<TargetHealthDescription> targets = res.getTargetHealthDescriptions();
@@ -131,10 +131,10 @@ public class ELBIsInstanceRegisteredStep extends Step {
 				}
 			}
 			listener.getLogger().println(res.toString());
-			
+
 			return rval;
 		}
-		
+
 		public EnvVars getEnvVars() {
 			try {
 				return this.getContext().get(EnvVars.class);

--- a/src/main/java/de/taimos/pipeline/aws/elb/ELBRegisterInstanceStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/elb/ELBRegisterInstanceStep.java
@@ -123,16 +123,16 @@ public class ELBRegisterInstanceStep extends Step {
 			ArrayList<TargetDescription> arr = new ArrayList<TargetDescription>();
 			arr.add(new TargetDescription().withId(this.step.instanceID).withPort(this.step.port));
 			RegisterTargetsRequest request = new RegisterTargetsRequest().withTargetGroupArn(this.step.targetGroupARN).withTargets( arr );
-			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getEnvVars());
+			AmazonElasticLoadBalancing client = AWSClientFactory.create(AmazonElasticLoadBalancingClientBuilder.standard(), this.getContext(), this.getEnvVars());
 			client.registerTargets(request);
-			
+
 			DescribeTargetHealthRequest req = new DescribeTargetHealthRequest().withTargetGroupArn(this.step.targetGroupARN);
 			DescribeTargetHealthResult res = client.describeTargetHealth(req);
 			listener.getLogger().println(res.toString());
-			
+
 			return null;
 		}
-		
+
 		public EnvVars getEnvVars() {
 			try {
 				return this.getContext().get(EnvVars.class);

--- a/src/main/resources/de/taimos/pipeline/aws/PluginImpl/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/PluginImpl/config.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+	<f:section title="${%Pipeline: AWS Steps}" name="enableCredentialsFromNode">
+		<f:entry title="${%Retrieve credentials from node}" description="${%By default, the master's instance profile is used}">
+			<f:checkbox field="enableCredentialsFromNode"/>
+		</f:entry>
+	</f:section>
+</j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/PluginImpl/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/PluginImpl/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 	<f:section title="${%Pipeline: AWS Steps}" name="enableCredentialsFromNode">
-		<f:entry title="${%Retrieve credentials from node}" description="${%By default, the master's instance profile is used}">
+		<f:entry title="${%Retrieve credentials from node}" description="${%Restrict all nodes from accessing the master node's credentials}">
 			<f:checkbox field="enableCredentialsFromNode"/>
 		</f:entry>
 	</f:section>

--- a/src/test/java/de/taimos/pipeline/aws/S3PresignUrlStepTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3PresignUrlStepTests.java
@@ -3,27 +3,41 @@ package de.taimos.pipeline.aws;
 
 import com.amazonaws.HttpMethod;
 import com.amazonaws.client.builder.AwsSyncClientBuilder;
+
 import com.amazonaws.services.s3.AmazonS3;
+
 import hudson.EnvVars;
+
+import java.net.URL;
+import java.util.Date;
+
 import org.assertj.core.api.Assertions;
+
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
 import org.joda.time.DateTime;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.jvnet.hudson.test.JenkinsRule;
+
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
 import org.powermock.api.mockito.PowerMockito;
+
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.net.URL;
-import java.util.Date;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AWSClientFactory.class)
@@ -38,7 +52,7 @@ public class S3PresignUrlStepTests {
 	public void setupSdk() throws Exception {
 		PowerMockito.mockStatic(AWSClientFactory.class);
 		this.s3 = Mockito.mock(AmazonS3.class);
-		PowerMockito.when(AWSClientFactory.create(Mockito.any(AwsSyncClientBuilder.class), Mockito.any(EnvVars.class)))
+		PowerMockito.when(AWSClientFactory.create(Mockito.any(AwsSyncClientBuilder.class), Mockito.any(StepContext.class), Mockito.any(EnvVars.class)))
 				.thenReturn(this.s3);
 	}
 

--- a/src/test/java/de/taimos/pipeline/aws/SerializableAWSCredentialsProviderTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/SerializableAWSCredentialsProviderTest.java
@@ -1,0 +1,44 @@
+package de.taimos.pipeline.aws;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SerializableAWSCredentialsProviderTest {
+
+	public static final String ACCESS_KEY_ID = "access_key_id";
+	public static final String SECRET_KEY_ID = "secret_key_id";
+	public static final String SESSION_TOKEN = "session_token";
+
+	@Test
+	public void serializeBasicAWSCredentials() throws Exception {
+		BasicAWSCredentials awsCreds = new BasicAWSCredentials(
+			ACCESS_KEY_ID,
+			SECRET_KEY_ID
+		);
+		AWSCredentialsProvider provider = new AWSStaticCredentialsProvider(awsCreds);
+		SerializableAWSCredentialsProvider serializedProvider = new SerializableAWSCredentialsProvider(provider);
+		Assert.assertEquals(ACCESS_KEY_ID, serializedProvider.getCredentials().getAWSAccessKeyId());
+		Assert.assertEquals(SECRET_KEY_ID, serializedProvider.getCredentials().getAWSSecretKey());
+	}
+
+	@Test
+	public void serializeBasicSessionCredentials() throws Exception {
+		BasicSessionCredentials awsCreds = new BasicSessionCredentials(
+			ACCESS_KEY_ID,
+			SECRET_KEY_ID,
+			SESSION_TOKEN
+		);
+		AWSCredentialsProvider provider = new AWSStaticCredentialsProvider(awsCreds);
+		SerializableAWSCredentialsProvider serializedProvider = new SerializableAWSCredentialsProvider(provider);
+		BasicSessionCredentials serializedCredentials = (BasicSessionCredentials) serializedProvider.getCredentials();
+		Assert.assertEquals(ACCESS_KEY_ID, serializedCredentials.getAWSAccessKeyId());
+		Assert.assertEquals(SECRET_KEY_ID, serializedCredentials.getAWSSecretKey());
+		Assert.assertEquals(SESSION_TOKEN, serializedCredentials.getSessionToken());
+	}
+
+}

--- a/src/test/java/de/taimos/pipeline/aws/WithAWSStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/WithAWSStepTest.java
@@ -181,7 +181,7 @@ public class WithAWSStepTest {
 		final EnvVars envVars = new EnvVars();
 		envVars.put(AWSClientFactory.AWS_ENDPOINT_URL, "https://minio.mycompany.com");
 		envVars.put(AWSClientFactory.AWS_REGION, Regions.DEFAULT_REGION.getName());
-		final AmazonS3ClientBuilder amazonS3ClientBuilder = AWSClientFactory.configureBuilder(AmazonS3ClientBuilder.standard(), envVars);
+		final AmazonS3ClientBuilder amazonS3ClientBuilder = AWSClientFactory.configureBuilder(AmazonS3ClientBuilder.standard(), null, envVars);
 		Assert.assertEquals("https://minio.mycompany.com", amazonS3ClientBuilder.getEndpoint().getServiceEndpoint());
 
 	}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/jenkinsci/pipeline-aws-plugin/issues/64


* **What is the new behavior (if this is a feature change)?**

1. Adds a global configuration option to always fetch credentials from the current running node. ![image](https://user-images.githubusercontent.com/4519234/98551798-bd6fd500-226b-11eb-92db-34043803cccb.png)
2. Adds a `useNode` boolean to `withAWS` that will retrieve credentials from the node in scope



* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No



* **Other information**: