### PR TITLE
Fix wrong partition when assuming role (#250)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,6 +1077,7 @@ ebWaitOnEnvironmentHealth(
 ## current master
 * Add Elastic Beanstalk steps (`ebCreateApplication, ebCreateApplicationVersion, ebCreateConfigurationTemplate, ebCreateEnvironment, ebSwapEnvironmentCNAMEs, ebWaitOnEnvironmentStatus, ebWaitOnEnvironmentHealth`) 
 * Fix documentation for lambdaVersionCleanup
+* Fix wrong partition detection when assuming role
 
 ## 1.42
 * Adds new parameters to cfnDelete for roleArn, clientRequestToken, and retainResources.

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -372,7 +372,7 @@ public class WithAWSStep extends Step {
 				AWSSecurityTokenService sts = AWSClientFactory.create(AWSSecurityTokenServiceClientBuilder.standard(), this.envVars);
 
 				AssumeRole assumeRole = IamRoleUtils.validRoleArn(this.step.getRole()) ? new AssumeRole(this.step.getRole()) :
-						new AssumeRole(this.step.getRole(), this.createAccountId(sts), IamRoleUtils.selectPartitionName(this.step.getRegion()));
+						new AssumeRole(this.step.getRole(), this.createAccountId(sts), this.step.getRegion());
 				assumeRole.withDurationSeconds(this.step.getDuration());
 				assumeRole.withExternalId(this.step.getExternalId());
 				assumeRole.withPolicy(this.step.getPolicy());
@@ -380,6 +380,7 @@ public class WithAWSStep extends Step {
 				assumeRole.withSessionName(this.createRoleSessionName());
 
 				this.getContext().get(TaskListener.class).getLogger().format("Requesting assume role");
+				this.getContext().get(TaskListener.class).getLogger().format("Assuming role ARN is %s", assumeRole.toString());
 				AssumedRole assumedRole = assumeRole.assumedRole(sts);
 				this.getContext().get(TaskListener.class).getLogger().format("Assumed role %s with id %s %n ", assumedRole.getAssumedRoleUser().getArn(), assumedRole.getAssumedRoleUser().getAssumedRoleId());
 

--- a/src/main/java/de/taimos/pipeline/aws/utils/AssumedRole.java
+++ b/src/main/java/de/taimos/pipeline/aws/utils/AssumedRole.java
@@ -64,6 +64,11 @@ public class AssumedRole {
 		public AssumeRole(final String roleArn) {
 			this.roleArn = roleArn;
 		}
+
+		@Override
+		public String toString() {
+			return this.roleArn;
+		}
 		
 		public AssumeRole withSessionName(final String sessionName) {
 			this.sessionName = StringUtils.isNullOrEmpty(sessionName) ? null : sessionName;

--- a/src/test/java/de/taimos/pipeline/aws/WithAWSStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/WithAWSStepTest.java
@@ -315,6 +315,23 @@ public class WithAWSStepTest {
 	}
 
 	@Test
+	public void testStepWithAssumeRoleChina() throws Exception {
+		WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "testStepWithAssumeRoleChina");
+		job.setDefinition(new CpsFlowDefinition(""
+				+ "node {\n"
+				+ "  withAWS (role: 'myRole', roleAccount: '123456789012', region: 'cn-north-1') {\n"
+				+ "    echo 'It works!'\n"
+				+ "  }\n"
+				+ "}\n", true)
+		);
+		WorkflowRun workflowRun = job.scheduleBuild2(0).get();
+		jenkinsRule.waitForCompletion(workflowRun);
+		jenkinsRule.assertBuildStatus(Result.FAILURE, workflowRun);
+		jenkinsRule.assertLogContains("Requesting assume role", workflowRun);
+		jenkinsRule.assertLogContains("Assuming role ARN is arn:aws-cn:iam::123456789012:role/myRole" , workflowRun);
+	}
+
+	@Test
 	public void testListCredentials() throws Exception {
 		Folder folder = jenkinsRule.jenkins.createProject(Folder.class, "folder" + jenkinsRule.jenkins.getItems().size());
 		CredentialsStore folderStore = this.getFolderStore(folder);


### PR DESCRIPTION
- removing second call to selectPartitionName, as constructor expects region and calls the same method too
- add log message with role ARN before API call
- check log message in test with cn-north-1 region

* **Please check if the PR fulfills these requirements**
- [+] The commit message describes your change
- [+] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [+] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix 


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/jenkinsci/pipeline-aws-plugin/issues/250


* **What is the new behavior (if this is a feature change)?**
Regions outside of standard AWS partition name ("aws"), such as China ("aws-cn") would work when withAWS is used with "role". Assume role would have proper partition in a constructed ARN.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No breaking changes

