### PR TITLE
Fix resource listing for lambdaVersionCleanup when using a cloudformation stack with lots of resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,6 +1078,7 @@ ebWaitOnEnvironmentHealth(
 * Add Elastic Beanstalk steps (`ebCreateApplication, ebCreateApplicationVersion, ebCreateConfigurationTemplate, ebCreateEnvironment, ebSwapEnvironmentCNAMEs, ebWaitOnEnvironmentStatus, ebWaitOnEnvironmentHealth`) 
 * Fix documentation for lambdaVersionCleanup
 * Fix wrong partition detection when assuming role
+* Fix resource listing for lambdaVersionCleanup when using a cloudformation stack with lots of resources
 
 ## 1.42
 * Adds new parameters to cfnDelete for roleArn, clientRequestToken, and retainResources.


### PR DESCRIPTION
DescribeStackResources limits to 100 resources
Use ListStackResources instead of DescribeStackResources

* **Please check if the PR fulfills these requirements**
- [*] The commit message describes your change
- [*] Tests for the changes have been added if possible (for bug fixes / features)
- [*] Docs have been added / updated (for bug fixes / features)
- [*] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix


* **What is the current behavior?** (You can also link to an open issue here)
large stacks have resources ignored


* **What is the new behavior (if this is a feature change)?**
Uses the paginated cloudformation API


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**: