### PR TITLE
Fix changeset with no changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,6 @@ ebWaitOnEnvironmentHealth(
 * Add ELB methods to mangage instances during deployemnts ( [elbRegisterInstance](#elbRegisterInstance), [elbDeregisterInstance](#elbDeregisterInstance), [elbIsInstanceRegistered](#elbIsInstanceRegistered), [elbIsInstanceDeregistered](#elbIsInstanceDeregistered) )
 * Add tags to files uploaded with S3Upload
 * Add `createDeployment` step
-* fix `cfnExecuteChangeSet` when no resource change (#210)
 
 ## 1.41
 * Add batching support for cfnUpdateStackSet

--- a/README.md
+++ b/README.md
@@ -1079,12 +1079,14 @@ ebWaitOnEnvironmentHealth(
 * Fix documentation for lambdaVersionCleanup
 * Fix wrong partition detection when assuming role
 * Fix resource listing for lambdaVersionCleanup when using a cloudformation stack with lots of resources
+* Fix cfnExecuteChangeSet to correctly handle no resource change, but updates to outputs (#210)
 
 ## 1.42
 * Adds new parameters to cfnDelete for roleArn, clientRequestToken, and retainResources.
 * Add ELB methods to mangage instances during deployemnts ( [elbRegisterInstance](#elbRegisterInstance), [elbDeregisterInstance](#elbDeregisterInstance), [elbIsInstanceRegistered](#elbIsInstanceRegistered), [elbIsInstanceDeregistered](#elbIsInstanceDeregistered) )
 * Add tags to files uploaded with S3Upload
 * Add `createDeployment` step
+* fix `cfnExecuteChangeSet` when no resource change (#210)
 
 ## 1.41
 * Add batching support for cfnUpdateStackSet

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -30,6 +30,7 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
 import com.amazonaws.services.cloudformation.model.Capability;
 import com.amazonaws.services.cloudformation.model.ChangeSetType;
+import com.amazonaws.services.cloudformation.model.ChangeSetStatus;
 import com.amazonaws.services.cloudformation.model.CreateChangeSetRequest;
 import com.amazonaws.services.cloudformation.model.CreateStackRequest;
 import com.amazonaws.services.cloudformation.model.DeleteChangeSetRequest;
@@ -104,9 +105,9 @@ public class CloudFormationStack {
 		}
 	}
 
-	private boolean changeSetHasChanges(String changeSetName) {
+	private boolean emptyChangeSet(String changeSetName) {
 		DescribeChangeSetResult result = this.client.describeChangeSet(new DescribeChangeSetRequest().withStackName(this.stack).withChangeSetName(changeSetName));
-		return !result.getChanges().isEmpty();
+		return ChangeSetStatus.FAILED.name().equals(result.getStatus()) && result.getStatusReason().toLowerCase().contains("the submitted information didn't contain changes");
 	}
 
 	public Map<String, String> describeOutputs() {
@@ -229,7 +230,7 @@ public class CloudFormationStack {
 
 		} catch (ExecutionException e) {
 			try {
-				if (this.changeSetExists(changeSetName) && !this.changeSetHasChanges(changeSetName)) {
+				if (this.changeSetExists(changeSetName) && this.emptyChangeSet(changeSetName)) {
 					// Ignore the failed creation of a change set with no changes.
 					this.listener.getLogger().format("Created empty change set %s for stack %s %n", changeSetName, this.stack);
 					return;
@@ -243,7 +244,7 @@ public class CloudFormationStack {
 	}
 
 	public Map<String, String> executeChangeSet(String changeSetName, PollConfiguration pollConfiguration) throws ExecutionException {
-		if (!this.changeSetHasChanges(changeSetName) || !this.exists()) {
+		if (!this.exists() || this.emptyChangeSet(changeSetName)) {
 			// If the change set has no changes or the stack was not prepared we should simply delete it.
 			this.listener.getLogger().format("Deleting empty change set %s for stack %s %n", changeSetName, this.stack);
 			DeleteChangeSetRequest req = new DeleteChangeSetRequest().withChangeSetName(changeSetName).withStackName(this.stack);

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -243,8 +243,8 @@ public class CloudFormationStack {
 	}
 
 	public Map<String, String> executeChangeSet(String changeSetName, PollConfiguration pollConfiguration) throws ExecutionException {
-		if (!this.exists()) {
-			// If the stack was not prepared we should simply delete it.
+		if (!this.changeSetHasChanges(changeSetName) || !this.exists()) {
+			// If the change set has no changes or the stack was not prepared we should simply delete it.
 			this.listener.getLogger().format("Deleting empty change set %s for stack %s %n", changeSetName, this.stack);
 			DeleteChangeSetRequest req = new DeleteChangeSetRequest().withChangeSetName(changeSetName).withStackName(this.stack);
 			this.client.deleteChangeSet(req);

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
@@ -111,11 +111,11 @@ public class CloudformationStackTests {
 	public void executeChangeSetWithChanges() throws ExecutionException {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
 		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
-		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 
-		// with resource changes in changeset
+		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
 		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
 													  .withStackName("foo")
 													  .withChangeSetName("bar")
@@ -138,23 +138,17 @@ public class CloudformationStackTests {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
-		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
 		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
-
-		// no resource changes in changeset
 		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
 													  .withStackName("foo")
 													  .withChangeSetName("bar")
 		)).thenReturn(new DescribeChangeSetResult());
-
 		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
-				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withStackStatus("CREATE_COMPLETE").withOutputs(new Output().withOutputKey("bar").withOutputValue("baz"))));
+				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withOutputs(new Output().withOutputKey("bar").withOutputValue("baz"))));
 
 		Map<String, String> outputs = stack.executeChangeSet("bar", PollConfiguration.DEFAULT);
-
-		Mockito.verify(client).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
-		Mockito.verify(this.eventPrinter).waitAndPrintStackEvents(Mockito.eq("foo"), Mockito.any(Waiter.class), Mockito.eq(PollConfiguration.DEFAULT));
-		Assertions.assertThat(outputs).containsEntry("bar", "baz").containsEntry("jenkinsStackUpdateStatus", "true");
+		Mockito.verify(client, Mockito.never()).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
+		Assertions.assertThat(outputs).containsEntry("bar", "baz").containsEntry("jenkinsStackUpdateStatus", "false");
 	}
 
 	@Test

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/CloudformationStackTests.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
 import com.amazonaws.services.cloudformation.model.Capability;
 import com.amazonaws.services.cloudformation.model.Change;
+import com.amazonaws.services.cloudformation.model.ChangeSetStatus;
 import com.amazonaws.services.cloudformation.model.ChangeSetType;
 import com.amazonaws.services.cloudformation.model.CreateChangeSetRequest;
 import com.amazonaws.services.cloudformation.model.CreateStackRequest;
@@ -34,6 +35,7 @@ import com.amazonaws.services.cloudformation.model.OnFailure;
 import com.amazonaws.services.cloudformation.model.Output;
 import com.amazonaws.services.cloudformation.model.RollbackConfiguration;
 import com.amazonaws.services.cloudformation.model.Stack;
+import com.amazonaws.services.cloudformation.model.StackStatus;
 import com.amazonaws.services.cloudformation.model.UpdateStackRequest;
 import com.amazonaws.services.cloudformation.waiters.AmazonCloudFormationWaiters;
 import com.amazonaws.waiters.Waiter;
@@ -134,7 +136,7 @@ public class CloudformationStackTests {
 	}
 
 	@Test
-	public void noExecuteChangeSetIfNoChanges() throws ExecutionException {
+	public void doNotExecuteChangeSetIfNoChanges() throws ExecutionException {
 		TaskListener taskListener = Mockito.mock(TaskListener.class);
 		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
 		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
@@ -142,13 +144,33 @@ public class CloudformationStackTests {
 		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
 													  .withStackName("foo")
 													  .withChangeSetName("bar")
-		)).thenReturn(new DescribeChangeSetResult());
+		)).thenReturn(new DescribeChangeSetResult().withStatus(ChangeSetStatus.FAILED).withStatusReason("the submitted information didn't contain changes"));
 		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
 				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withOutputs(new Output().withOutputKey("bar").withOutputValue("baz"))));
 
 		Map<String, String> outputs = stack.executeChangeSet("bar", PollConfiguration.DEFAULT);
 		Mockito.verify(client, Mockito.never()).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
 		Assertions.assertThat(outputs).containsEntry("bar", "baz").containsEntry("jenkinsStackUpdateStatus", "false");
+	}
+
+	@Test
+	public void executeChangeSetIfNoChangesButSuccessfulStatus() throws ExecutionException {
+		TaskListener taskListener = Mockito.mock(TaskListener.class);
+		Mockito.when(taskListener.getLogger()).thenReturn(System.out);
+		AmazonCloudFormation client = Mockito.mock(AmazonCloudFormation.class);
+		CloudFormationStack stack = new CloudFormationStack(client, "foo", taskListener);
+		Mockito.when(client.describeChangeSet(new DescribeChangeSetRequest()
+				.withStackName("foo")
+				.withChangeSetName("bar")
+		)).thenReturn(new DescribeChangeSetResult().withStatus(ChangeSetStatus.CREATE_COMPLETE));
+		Mockito.when(client.describeStacks(new DescribeStacksRequest().withStackName("foo")))
+				.thenReturn(new DescribeStacksResult().withStacks(new Stack().withStackStatus(StackStatus.CREATE_COMPLETE).withOutputs(new Output().withOutputKey("bar").withOutputValue("baz"))));
+		Mockito.when(client.waiters()).thenReturn(new AmazonCloudFormationWaiters(client));
+
+		Map<String, String> outputs = stack.executeChangeSet("bar", PollConfiguration.DEFAULT);
+		Mockito.verify(client).executeChangeSet(Mockito.any(ExecuteChangeSetRequest.class));
+		Mockito.verify(this.eventPrinter).waitAndPrintStackEvents(Mockito.eq("foo"), Mockito.any(Waiter.class), Mockito.eq(PollConfiguration.DEFAULT));
+		Assertions.assertThat(outputs).containsEntry("bar", "baz");
 	}
 
 	@Test


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes support for changesets that have zero change. The previous fix solved the case of zero resource changes, but stack output changes. This handles both cases


* **What is the current behavior?** (You can also link to an open issue here)
A change set with zero changes fails to execute. Before the previous change, the change set was deleted and not executed 


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
It shouldn't


* **Other information**:

    Fix #210 with changesets

    Change sets have a status that needs to be validated on whether the
    change set was successful or not.

    1) Failed, with a message that the changeset was empty
    2) success, with no changes (such as output changes)

    Previously, the status was not consulted, only the number of changes.
    This did not correctly apply changes when it is only the output that
    changes.

    The previous attempt to fix this issue did not correctly handle an empty
    changeset that failed to create due to no changes.