### PR TITLE
Text upload fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,6 +1079,7 @@ ebWaitOnEnvironmentHealth(
 * Fix documentation for lambdaVersionCleanup
 * Fix wrong partition detection when assuming role
 * Fix resource listing for lambdaVersionCleanup when using a cloudformation stack with lots of resources
+* Fix issues around S3UploadFile with text string argument
 
 ## 1.42
 * Adds new parameters to cfnDelete for roleArn, clientRequestToken, and retainResources.

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -347,8 +347,8 @@ public class S3UploadStep extends AbstractS3Step {
 			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
 			Preconditions.checkArgument(text != null || file != null || includePathPattern != null, "At least one argument of Text, File or IncludePathPattern must be included");
 			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be used together");
-			Preconditions.checkArgument(text == null || file == null, "Text and IncludePathPattern cannot be used together");
-			Preconditions.checkArgument(includePathPattern == null || text == null, "File and Text cannot be used together");
+			Preconditions.checkArgument(text == null || file == null, "Text and File cannot be used together");
+			Preconditions.checkArgument(includePathPattern == null || text == null, "IncludePathPattern and Text cannot be used together");
 
 			final List<FilePath> children = new ArrayList<>();
 			final FilePath dir;

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -345,8 +345,10 @@ public class S3UploadStep extends AbstractS3Step {
 			}
 
 			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
-			Preconditions.checkArgument(text != null || file != null || includePathPattern != null, "File or IncludePathPattern must not be null");
-			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be use together");
+			Preconditions.checkArgument(text != null || file != null || includePathPattern != null, "At least one argument of Text, File or IncludePathPattern must be included");
+			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be used together");
+			Preconditions.checkArgument(text == null || file == null, "Text and IncludePathPattern cannot be used together");
+			Preconditions.checkArgument(includePathPattern == null || text == null, "File and Text cannot be used together");
 
 			final List<FilePath> children = new ArrayList<>();
 			final FilePath dir;

--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -325,7 +325,6 @@ public class S3UploadStep extends AbstractS3Step {
 			final boolean verbose = this.step.getVerbose();
 			boolean omitSourcePath = false;
 			boolean sendingText = false;
-			String localPath = null;
 
 			if (this.step.getMetadatas() != null && this.step.getMetadatas().length != 0) {
 				for (String metadata : this.step.getMetadatas()) {
@@ -346,7 +345,7 @@ public class S3UploadStep extends AbstractS3Step {
 			}
 
 			Preconditions.checkArgument(bucket != null && !bucket.isEmpty(), "Bucket must not be null or empty");
-			Preconditions.checkArgument(file != null || includePathPattern != null, "File or IncludePathPattern must not be null");
+			Preconditions.checkArgument(text != null || file != null || includePathPattern != null, "File or IncludePathPattern must not be null");
 			Preconditions.checkArgument(includePathPattern == null || file == null, "File and IncludePathPattern cannot be use together");
 
 			final List<FilePath> children = new ArrayList<>();
@@ -371,7 +370,7 @@ public class S3UploadStep extends AbstractS3Step {
 			TaskListener listener = Execution.this.getContext().get(TaskListener.class);
 
 			if (sendingText) {
-				listener.getLogger().format("Uploading text string to s3://%s/%s %n", bucket, localPath);
+				listener.getLogger().format("Uploading text string to s3://%s/%s %n", bucket, path);
 
 				S3ClientOptions amazonS3ClientOptions = Execution.this.step.createS3ClientOptions();
 				EnvVars envVars = Execution.this.getContext().get(EnvVars.class);
@@ -447,7 +446,7 @@ public class S3UploadStep extends AbstractS3Step {
 				}
 
 				listener.getLogger().println("Upload complete");
-				return String.format("s3://%s/%s", bucket, localPath);
+				return String.format("s3://%s/%s", bucket, path);
 			} else if (children.isEmpty()) {
 				listener.getLogger().println("Nothing to upload");
 				return null;

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -93,7 +93,7 @@ public class S3UploadStepTest {
 		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
 		Throwable t = Assertions.catchThrowable(execution::run);
 		Assert.assertTrue(t instanceof IllegalArgumentException);
-		Assert.assertEquals("File or IncludePathPattern must not be null", t.getMessage());
+		Assert.assertEquals("At least one argument of Text, File or IncludePathPattern must be included", t.getMessage());
 	}
 
 	@Test
@@ -104,7 +104,29 @@ public class S3UploadStepTest {
 		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
 		Throwable t = Assertions.catchThrowable(execution::run);
 		Assert.assertTrue(t instanceof IllegalArgumentException);
-		Assert.assertEquals("File and IncludePathPattern cannot be use together", t.getMessage());
+		Assert.assertEquals("File and IncludePathPattern cannot be used together", t.getMessage());
+	}
+
+	@Test
+	public void doNotAcceptFileAndIncludePathPatternArguments() throws Exception {
+		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
+		step.setText("Just some text content.");
+		step.setIncludePathPattern("*.txt");
+		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
+		Throwable t = Assertions.catchThrowable(execution::run);
+		Assert.assertTrue(t instanceof IllegalArgumentException);
+		Assert.assertEquals("Text and IncludePathPattern cannot be used together", t.getMessage());
+	}
+
+	@Test
+	public void doNotAcceptFileAndIncludePathPatternArguments() throws Exception {
+		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
+		step.setFile("file.txt");
+		step.setText("Just some text content.");
+		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
+		Throwable t = Assertions.catchThrowable(execution::run);
+		Assert.assertTrue(t instanceof IllegalArgumentException);
+		Assert.assertEquals("File and Text cannot be used together", t.getMessage());
 	}
 
 }

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -97,7 +97,7 @@ public class S3UploadStepTest {
 	}
 
 	@Test
-	public void doNotAcceptFileAndIncludePathPatternArguments() throws Exception {
+	public void doNotAcceptFileAndIncludePathPatternArgumentsFilePattern() throws Exception {
 		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
 		step.setFile("file.txt");
 		step.setIncludePathPattern("*.txt");
@@ -108,7 +108,7 @@ public class S3UploadStepTest {
 	}
 
 	@Test
-	public void doNotAcceptFileAndIncludePathPatternArguments() throws Exception {
+	public void doNotAcceptFileAndIncludePathPatternArgumentsTextPattern() throws Exception {
 		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
 		step.setText("Just some text content.");
 		step.setIncludePathPattern("*.txt");
@@ -119,7 +119,7 @@ public class S3UploadStepTest {
 	}
 
 	@Test
-	public void doNotAcceptFileAndIncludePathPatternArguments() throws Exception {
+	public void doNotAcceptFileAndIncludePathPatternArgumentsFileText() throws Exception {
 		S3UploadStep step = new S3UploadStep("my-bucket", false, false);
 		step.setFile("file.txt");
 		step.setText("Just some text content.");

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -115,7 +115,7 @@ public class S3UploadStepTest {
 		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
 		Throwable t = Assertions.catchThrowable(execution::run);
 		Assert.assertTrue(t instanceof IllegalArgumentException);
-		Assert.assertEquals("IncludePattern and Text cannot be used together", t.getMessage());
+		Assert.assertEquals("IncludePathPattern and Text cannot be used together", t.getMessage());
 	}
 
 	@Test

--- a/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3UploadStepTest.java
@@ -115,7 +115,7 @@ public class S3UploadStepTest {
 		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
 		Throwable t = Assertions.catchThrowable(execution::run);
 		Assert.assertTrue(t instanceof IllegalArgumentException);
-		Assert.assertEquals("Text and IncludePathPattern cannot be used together", t.getMessage());
+		Assert.assertEquals("IncludePattern and Text cannot be used together", t.getMessage());
 	}
 
 	@Test
@@ -126,7 +126,7 @@ public class S3UploadStepTest {
 		S3UploadStep.Execution execution = new S3UploadStep.Execution(step, Mockito.mock(StepContext.class));
 		Throwable t = Assertions.catchThrowable(execution::run);
 		Assert.assertTrue(t instanceof IllegalArgumentException);
-		Assert.assertEquals("File and Text cannot be used together", t.getMessage());
+		Assert.assertEquals("Text and File cannot be used together", t.getMessage());
 	}
 
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
[ X ] The commit message describes your change
[ X ] Tests for the changes have been added if possible (for bug fixes / features)
[ X ] Docs have been added / updated (for bug fixes / features)
[ X ] Changes are mentioned in the changelog (for bug fixes / features)

* **What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This is a bugfix PR. We've seen several reports that the S3UploadFile feature where a string value was used to populate the S3 object was working incorrectly. This PR fixes the errors that were introduced, and updates the precondition checks that were not working properly.

* **What is the current behavior? (You can also link to an open issue here)**
https://github.com/jenkinsci/pipeline-aws-plugin/issues/196
https://github.com/jenkinsci/pipeline-aws-plugin/pull/168

* **What is the new behavior (if this is a feature change)?**
As suggested by @webark in https://github.com/jenkinsci/pipeline-aws-plugin/pull/168, the localPath variable was replaced with the path variable. Additionally, I added and updated some of the precondition checks to confirm that one and only one of the parameters (text, file, includePathPattern) were provided.

* **Does this PR introduce a breaking change? (What changes might users need to make in their setup due to this PR?)**
This is a non-breaking change, just fixing a previously broken featureset. No updates to documentation are required.

* **Other information:**