### PR TITLE
Fix global configuration naming for JCasC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1090,13 +1090,13 @@ ebWaitOnEnvironmentHealth(
 # Changelog
 
 ## current master
-* Add Elastic Beanstalk steps (`ebCreateApplication, ebCreateApplicationVersion, ebCreateConfigurationTemplate, ebCreateEnvironment, ebSwapEnvironmentCNAMEs, ebWaitOnEnvironmentStatus, ebWaitOnEnvironmentHealth`) 
+* Add Elastic Beanstalk steps (`ebCreateApplication, ebCreateApplicationVersion, ebCreateConfigurationTemplate, ebCreateEnvironment, ebSwapEnvironmentCNAMEs, ebWaitOnEnvironmentStatus, ebWaitOnEnvironmentHealth`)
 * Fix documentation for lambdaVersionCleanup
 * Fix wrong partition detection when assuming role
 * Fix resource listing for lambdaVersionCleanup when using a cloudformation stack with lots of resources
 * Fix issues around S3UploadFile with text string argument
 * Fix cfnExecuteChangeSet to correctly handle no resource change, but updates to outputs (#210)
-* Fix global configuration naming for JCasC
+* Fix global configuration naming for JCasC. Please note that this is a breaking change if JCasC is defined. This can be fixed by renaming pluginImpl --> pipelineStepsAWS.
 
 ## 1.42
 * Adds new parameters to cfnDelete for roleArn, clientRequestToken, and retainResources.

--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,7 @@ ebWaitOnEnvironmentHealth(
 * Fix resource listing for lambdaVersionCleanup when using a cloudformation stack with lots of resources
 * Fix issues around S3UploadFile with text string argument
 * Fix cfnExecuteChangeSet to correctly handle no resource change, but updates to outputs (#210)
+* Fix global configuration naming for JCasC
 
 ## 1.42
 * Adds new parameters to cfnDelete for roleArn, clientRequestToken, and retainResources.

--- a/src/main/java/de/taimos/pipeline/aws/PluginImpl.java
+++ b/src/main/java/de/taimos/pipeline/aws/PluginImpl.java
@@ -33,11 +33,13 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import org.jenkinsci.Symbol;
 
 /**
 * Global configuration
 */
 @Extension
+@Symbol("pipelineStepsAWS")
 public class PluginImpl extends GlobalConfiguration {
 
 	private boolean enableCredentialsFromNode;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes the naming in the global configuration so that the [JCasC](https://www.jenkins.io/projects/jcasc/) is clear.

* **What is the current behavior?** (You can also link to an open issue here)
The current key is `pluginImpl` which is ambiguous when defining several different plugins in JCasC.

* **What is the new behavior (if this is a feature change)?**
The new behaviour renames the configuration key to be `pipelineStepsAWS` rather than `pluginImpl`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
If JCasC is defined, a rename would be required. `pluginImpl --> pipelineStepsAWS`

* **Other information**:

#### Before
![image](https://user-images.githubusercontent.com/4519234/102305486-3e3a8480-3f2e-11eb-9ebe-d4dc9e0b8d0b.png)


#### After
![image](https://user-images.githubusercontent.com/4519234/102305480-37137680-3f2e-11eb-98e2-2c4006aa2caa.png)
