### PR TITLE
Extend ebSwapEnvironmentCNAME step to accept CNAME identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,8 +1014,10 @@ Swaps the CNAMEs of the environments. This is useful for [Blue-Green deployments
 Arguments:
  * sourceEnvironmentId - Id of the source environment. _Should be used with destinationEnvironmentId_
  * sourceEnvironmentName - Name of the source environment. _Should be used with destinationEnvironmentName_
+ * sourceEnvironmentCNAME - CNAME of the source environment. If provided, it will be used to lookup the id and name of the source environment.
  * destinationEnvironmentId - Id of the destination environment. _Should be used with sourceEnvironmentId_
  * destinationEnvironmentName - Name of the destination environment. _Should be used with sourceEnvironmentName_
+ * destinationEnvironmentCNAME - CNAME of the destunatuin environment. If provided, it will be used to lookup the id and name of the destination environment. 
 
 [AWS reference](https://docs.aws.amazon.com/elasticbeanstalk/latest/api/API_SwapEnvironmentCNAMEs.html  )
 
@@ -1030,6 +1032,12 @@ ebSwapEnvironmentCNAMEs(
 ebCreateEnvironment(
     sourceEnvironmentName: "production",
     destinationEnvironmentName: "production-2"
+)
+
+// Swap CNAMEs using the source environment name and destination environment CNAME
+ebCreateEnvironment(
+        sourceEnvironmentName: "green",
+        destinationEnvironmentCNAME: "production.eu-west-1.elasticbeanstalk.com"
 )
 ```
 
@@ -1092,6 +1100,7 @@ ebWaitOnEnvironmentHealth(
 ## current master
 * Fix global configuration naming for JCasC. Please note that this is a breaking change if JCasC is defined. This can be fixed by renaming pluginImpl --> pipelineStepsAWS.
 * Fix Elastic Beanstalk client creation bug that ignored provided configurations in the withAWSStep
+* Add CNAME parameters to Elastic Beanstalk `ebSwapEnvironmentCNAMEs` command that lookup the required id and name params
 
 ## 1.43
 * Add Elastic Beanstalk steps (`ebCreateApplication, ebCreateApplicationVersion, ebCreateConfigurationTemplate, ebCreateEnvironment, ebSwapEnvironmentCNAMEs, ebWaitOnEnvironmentStatus, ebWaitOnEnvironmentHealth`) 

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStep.java
@@ -2,6 +2,11 @@ package de.taimos.pipeline.aws.eb;
 
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.AWSElasticBeanstalkException;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
+import com.amazonaws.services.elasticbeanstalk.model.ResourceNotFoundException;
 import com.amazonaws.services.elasticbeanstalk.model.SwapEnvironmentCNAMEsRequest;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
@@ -22,8 +27,10 @@ import java.util.Set;
 public class EBSwapEnvironmentCNAMEsStep extends Step {
 	private String sourceEnvironmentId;
 	private String sourceEnvironmentName;
+	private String sourceEnvironmentCNAME;
 	private String destinationEnvironmentId;
 	private String destinationEnvironmentName;
+	private String destinationEnvironmentCNAME;
 
 	@DataBoundConstructor
 	public EBSwapEnvironmentCNAMEsStep() {
@@ -52,6 +59,16 @@ public class EBSwapEnvironmentCNAMEsStep extends Step {
 	@DataBoundSetter
 	public void setDestinationEnvironmentName(String destinationEnvironmentName) {
 		this.destinationEnvironmentName = destinationEnvironmentName;
+	}
+
+	@DataBoundSetter
+	public void setDestinationEnvironmentCNAME(String destinationEnvironmentCNAME) {
+		this.destinationEnvironmentCNAME = destinationEnvironmentCNAME;
+	}
+
+	@DataBoundSetter
+	public void setSourceEnvironmentCNAME(String sourceEnvironmentCNAME) {
+		this.sourceEnvironmentCNAME = sourceEnvironmentCNAME;
 	}
 
 	@Extension
@@ -92,6 +109,11 @@ public class EBSwapEnvironmentCNAMEsStep extends Step {
 					this.getContext().get(EnvVars.class)
 			);
 
+			if (step.sourceEnvironmentCNAME != null || step.destinationEnvironmentCNAME != null) {
+				listener.getLogger().format("Looking up identifiers based on CNAMEs provided %n");
+				updateEnvironmentIdsFromUrl(client);
+			}
+
 			listener.getLogger().format("Swapping CNAMEs for environments %s(%s) and %s(%s) %n",
 					step.sourceEnvironmentName,
 					step.sourceEnvironmentId,
@@ -114,6 +136,38 @@ public class EBSwapEnvironmentCNAMEsStep extends Step {
 			);
 
 			return null;
+		}
+
+		private void updateEnvironmentIdsFromUrl(AWSElasticBeanstalk client) {
+			DescribeEnvironmentsRequest request = new DescribeEnvironmentsRequest();
+			DescribeEnvironmentsResult result = client.describeEnvironments(request);
+
+			if (result.getEnvironments().isEmpty()) {
+				throw new AWSElasticBeanstalkException("No environments found. Please check the aws credentials and region");
+			}
+
+			EnvironmentDescription environment;
+			if (step.sourceEnvironmentCNAME != null) {
+				environment = result.getEnvironments().stream()
+						.filter(env -> step.sourceEnvironmentCNAME.equalsIgnoreCase(env.getCNAME()))
+						.findFirst()
+						.orElseThrow(() -> new ResourceNotFoundException(
+								String.format("Environment with url %s not found", step.sourceEnvironmentCNAME)));
+
+				step.sourceEnvironmentId = environment.getEnvironmentId();
+				step.sourceEnvironmentName = environment.getEnvironmentName();
+			}
+
+			if (step.destinationEnvironmentCNAME != null) {
+				environment = result.getEnvironments().stream()
+						.filter(env -> step.destinationEnvironmentCNAME.equalsIgnoreCase(env.getCNAME()))
+						.findFirst()
+						.orElseThrow(() -> new ResourceNotFoundException(
+								String.format("Environment with url %s not found", step.destinationEnvironmentCNAME)));
+
+				step.destinationEnvironmentId = environment.getEnvironmentId();
+				step.destinationEnvironmentName = environment.getEnvironmentName();
+			}
 		}
 	}
 }

--- a/src/test/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStepTest.java
@@ -1,6 +1,8 @@
 package de.taimos.pipeline.aws.eb;
 
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
+import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
 import com.amazonaws.services.elasticbeanstalk.model.SwapEnvironmentCNAMEsRequest;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -13,6 +15,8 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AWSClientFactory.class)
@@ -44,6 +48,39 @@ public class EBSwapEnvironmentCNAMEsStepTest {
 
         AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
         execution.run();
+
+        Mockito.verify(client, Mockito.times(1)).swapEnvironmentCNAMEs(captor.capture());
+        Assert.assertEquals("source-id", captor.getValue().getSourceEnvironmentId());
+        Assert.assertEquals("source-name", captor.getValue().getSourceEnvironmentName());
+        Assert.assertEquals("destination-id", captor.getValue().getDestinationEnvironmentId());
+        Assert.assertEquals("destination-name", captor.getValue().getDestinationEnvironmentName());
+    }
+
+    @Test
+    public void swapCanBeDoneByCNAMELookup() throws Exception {
+        EBSwapEnvironmentCNAMEsStep step = new EBSwapEnvironmentCNAMEsStep();
+        step.setSourceEnvironmentCNAME("source-cname");
+        step.setDestinationEnvironmentCNAME("destination-cname");
+        EBSwapEnvironmentCNAMEsStep.Execution execution = new EBSwapEnvironmentCNAMEsStep.Execution(step, context);
+
+        AWSElasticBeanstalk client = EBTestingUtils.setupElasticBeanstalkClient();
+        DescribeEnvironmentsResult result = new DescribeEnvironmentsResult();
+        EnvironmentDescription sourceEnv = new EnvironmentDescription();
+        sourceEnv.setCNAME("source-cname");
+        sourceEnv.setEnvironmentId("source-id");
+        sourceEnv.setEnvironmentName("source-name");
+
+        EnvironmentDescription destinationEnv = new EnvironmentDescription();
+        destinationEnv.setCNAME("destination-cname");
+        destinationEnv.setEnvironmentId("destination-id");
+        destinationEnv.setEnvironmentName("destination-name");
+
+        result.setEnvironments(Arrays.asList(sourceEnv, destinationEnv));
+        Mockito.when(client.describeEnvironments(Mockito.any())).thenReturn(result);
+
+
+        execution.run();
+
 
         Mockito.verify(client, Mockito.times(1)).swapEnvironmentCNAMEs(captor.capture());
         Assert.assertEquals("source-id", captor.getValue().getSourceEnvironmentId());


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
The ebSwapEnvironmentCNAME only accepts the AWS CLI parameters: environment id and environment name.


* **What is the new behavior (if this is a feature change)?**
Extends the capability of the ebSwapEnvironmentCNAME step so that if can accept the CNAMEs as identifiers for the elastic beanstalk environment.
For blue/green deployments, the environment name or id of the current production environment may not be known/hard to find out in the jenkins pipeline. The CNAME, however, is likely static and used as a reference for DNS records. Therefore, it is useful to have the capability of identifying the environment from the CNAME instead of the AWS CLI supported parameters (id, name).


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No. These changes are backwards compatible with the ebSwapEnvironmentCNAME step.


* **Other information**: