### PR TITLE
Issue #274 fix verbose param in the s3UploadStep

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3UploadStep.java
@@ -460,7 +460,7 @@ public class S3UploadStep extends AbstractS3Step {
 					throw new FileNotFoundException(child.toURI().toString());
 				}
 
-				child.act(new RemoteUploader(Execution.this.step.createS3ClientOptions(), Execution.this.getContext().get(EnvVars.class), listener, bucket, path, metadatas, tags, acl, cacheControl, contentEncoding, contentType, contentDisposition, kmsId, sseAlgorithm, redirectLocation));
+				child.act(new RemoteUploader(Execution.this.step.createS3ClientOptions(), Execution.this.getContext().get(EnvVars.class), listener, bucket, path, metadatas, tags, acl, cacheControl, contentEncoding, contentType, contentDisposition, kmsId, sseAlgorithm, redirectLocation, verbose));
 
 				listener.getLogger().println("Upload complete");
 				return String.format("s3://%s/%s", bucket, path);
@@ -470,7 +470,7 @@ public class S3UploadStep extends AbstractS3Step {
 				for (FilePath child : children) {
 					fileList.add(child.act(FIND_FILE_ON_SLAVE));
 				}
-				dir.act(new RemoteListUploader(Execution.this.step.createS3ClientOptions(), Execution.this.getContext().get(EnvVars.class), listener, fileList, bucket, path, metadatas, tags, acl, cacheControl, contentEncoding, contentType, contentDisposition, kmsId, sseAlgorithm));
+				dir.act(new RemoteListUploader(Execution.this.step.createS3ClientOptions(), Execution.this.getContext().get(EnvVars.class), listener, fileList, bucket, path, metadatas, tags, acl, cacheControl, contentEncoding, contentType, contentDisposition, kmsId, sseAlgorithm, verbose));
 				listener.getLogger().println("Upload complete");
 				return String.format("s3://%s/%s", bucket, path);
 			}
@@ -496,8 +496,9 @@ public class S3UploadStep extends AbstractS3Step {
 		private final String kmsId;
 		private final String sseAlgorithm;
 		private final String redirectLocation;
+		private final boolean verbose;
 
-		RemoteUploader(S3ClientOptions amazonS3ClientOptions, EnvVars envVars, TaskListener taskListener, String bucket, String path, Map<String, String> metadatas, Map<String, String> tags, CannedAccessControlList acl, String cacheControl, String contentEncoding, String contentType, String contentDisposition, String kmsId, String sseAlgorithm, String redirectLocation) {
+		RemoteUploader(S3ClientOptions amazonS3ClientOptions, EnvVars envVars, TaskListener taskListener, String bucket, String path, Map<String, String> metadatas, Map<String, String> tags, CannedAccessControlList acl, String cacheControl, String contentEncoding, String contentType, String contentDisposition, String kmsId, String sseAlgorithm, String redirectLocation, boolean verbose) {
 			this.amazonS3ClientOptions = amazonS3ClientOptions;
 			this.envVars = envVars;
 			this.taskListener = taskListener;
@@ -513,6 +514,7 @@ public class S3UploadStep extends AbstractS3Step {
 			this.kmsId = kmsId;
 			this.sseAlgorithm = sseAlgorithm;
 			this.redirectLocation = redirectLocation;
+			this.verbose = verbose;
 		}
 
 		@Override
@@ -577,7 +579,9 @@ public class S3UploadStep extends AbstractS3Step {
 					final Upload upload = mgr.upload(request);
 					upload.addProgressListener((ProgressListener) progressEvent -> {
 						if (progressEvent.getEventType() == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
-							RemoteUploader.this.taskListener.getLogger().println("Finished: " + upload.getDescription());
+							if (this.verbose) {
+								RemoteUploader.this.taskListener.getLogger().println("Finished: " + upload.getDescription());
+							}
 						}
 					});
 					upload.waitForCompletion();
@@ -638,7 +642,9 @@ public class S3UploadStep extends AbstractS3Step {
 					for (final Upload upload : fileUpload.getSubTransfers()) {
 						upload.addProgressListener((ProgressListener) progressEvent -> {
 							if (progressEvent.getEventType() == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
-								RemoteUploader.this.taskListener.getLogger().println("Finished: " + upload.getDescription());
+								if (this.verbose) {
+									RemoteUploader.this.taskListener.getLogger().println("Finished: " + upload.getDescription());
+								}
 							}
 						});
 					}
@@ -672,8 +678,9 @@ public class S3UploadStep extends AbstractS3Step {
 		private final String contentDisposition;
 		private final String kmsId;
 		private final String sseAlgorithm;
+		private final boolean verbose;
 
-		RemoteListUploader(S3ClientOptions amazonS3ClientOptions, EnvVars envVars, TaskListener taskListener, List<File> fileList, String bucket, String path, Map<String, String> metadatas, Map<String, String> tags, CannedAccessControlList acl, final String cacheControl, final String contentEncoding, final String contentType, final String contentDisposition, String kmsId, String sseAlgorithm) {
+		RemoteListUploader(S3ClientOptions amazonS3ClientOptions, EnvVars envVars, TaskListener taskListener, List<File> fileList, String bucket, String path, Map<String, String> metadatas, Map<String, String> tags, CannedAccessControlList acl, final String cacheControl, final String contentEncoding, final String contentType, final String contentDisposition, String kmsId, String sseAlgorithm, boolean verbose) {
 			this.amazonS3ClientOptions = amazonS3ClientOptions;
 			this.envVars = envVars;
 			this.taskListener = taskListener;
@@ -689,6 +696,7 @@ public class S3UploadStep extends AbstractS3Step {
 			this.contentDisposition = contentDisposition;
 			this.kmsId = kmsId;
 			this.sseAlgorithm = sseAlgorithm;
+			this.verbose = verbose;
 		}
 
 		@Override
@@ -750,7 +758,9 @@ public class S3UploadStep extends AbstractS3Step {
 				for (final Upload upload : fileUpload.getSubTransfers()) {
 					upload.addProgressListener((ProgressListener) progressEvent -> {
 						if (progressEvent.getEventType() == ProgressEventType.TRANSFER_COMPLETED_EVENT) {
-							RemoteListUploader.this.taskListener.getLogger().println("Finished: " + upload.getDescription());
+							if (this.verbose) {
+								RemoteListUploader.this.taskListener.getLogger().println("Finished: " + upload.getDescription());
+							}
 						}
 					});
 				}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix. This pull request fixes the verbose parameter for s3UploadStep.



* **What is the current behavior?** (You can also link to an open issue here)
The verbose == false param disables only one of four log messages about file upload in the s3UploadStep.
https://github.com/jenkinsci/pipeline-aws-plugin/issues/274


* **What is the new behavior (if this is a feature change)?**
The verbose == false disables all log messages about file upload in the s3UploadStep.



* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
This is a non-breaking change.


* **Other information**: