### PR TITLE
feat: add option to disable parallel download

### DIFF
--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/config.jelly
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/config.jelly
@@ -18,4 +18,7 @@
 	<f:entry title="${%Enable Payload Signing}" field="payloadSigningEnabled">
 		<f:checkbox />
 	</f:entry>
+	<f:entry title="${%Disable parallel downloads}" field="disableParallelDownloads">
+		<f:checkbox />
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-disableParallelDownloads.html
+++ b/src/main/resources/de/taimos/pipeline/aws/S3DownloadStep/help-disableParallelDownloads.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  Pipeline: AWS Steps
+  %%
+  Copyright (C) 2016 - 2017 Taimos GmbH
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+	Disable parallel download (for system that don't support parallel download).
+</div>

--- a/src/test/java/de/taimos/pipeline/aws/S3DownloadStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/S3DownloadStepTest.java
@@ -27,20 +27,27 @@ import org.junit.Test;
 public class S3DownloadStepTest {
 	@Test
 	public void gettersWorkAsExpected() throws Exception {
-		S3DownloadStep step = new S3DownloadStep("my-file", "my-bucket", false, false);
+		S3DownloadStep step = new S3DownloadStep("my-file", "my-bucket", false, false, false);
 		Assert.assertEquals("my-file", step.getFile());
 		Assert.assertEquals("my-bucket", step.getBucket());
 	}
 
 	@Test
 	public void defaultPathIsEmpty() throws Exception {
-		S3DownloadStep step = new S3DownloadStep("my-file", "my-bucket", false, false);
+		S3DownloadStep step = new S3DownloadStep("my-file", "my-bucket", false, false, false);
 		Assert.assertEquals("", step.getPath());
 	}
 
 	@Test
 	public void defaultForceIsFalse() throws Exception {
-		S3DownloadStep step = new S3DownloadStep("my-file", "my-bucket", false, false);
+		S3DownloadStep step = new S3DownloadStep("my-file", "my-bucket", false, false, false);
 		Assert.assertFalse(step.isForce());
 	}
+
+	@Test
+	public void defaultDisabledParallelIsFalse() throws Exception {
+		S3DownloadStep step = new S3DownloadStep("my-file", "my-bucket", false, false, false);
+		Assert.assertFalse(step.isDisableParallelDownloads());
+	}
+
 }


### PR DESCRIPTION
Some provider fails to comply with s3 parallel downloads.
Add an option to disable it

http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/transfer/TransferManager.html#download(com.amazonaws.services.s3.model.GetObjectRequest,%20java.io.File,%20com.amazonaws.services.s3.transfer.internal.S3ProgressListener)
AWS announce of parallel download: https://aws.amazon.com/blogs/developer/parallelizing-large-downloads-for-optimal-speed/

* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
All download are running in parallel. By parallel we mean the parts composing a file is downloaded in parallel.

* **What is the new behavior (if this is a feature change)?**
If user enable the option, the download are not running in parallel
Behavior doesn't change if the user don't enable the option.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No, it is just feature flag