### PR TITLE
update aws-java-sdk version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.457</version>
+            <version>1.12.481-392.v8b_291cfcda_09</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
* 
When using the `withAWS` function to assume a role and access the me-central-1 (UAE) AWS region the following error occurs:

```
The security token included in the request is invalid
```

I've tried setting the `me-central-1` region using the `region` argument in the `withAWS` function, this doesn't work.
I've tried leaving the `region` argument of the `withAWS` function empty and after successfully assuming a role I set the `AWS_REGION` environment variable, this also doesn't work.

The me-central-1 region appears to have been added in [1.12.299](https://github.com/aws/aws-sdk-java/commit/b08cda01a176eed97fd6c7823c35747736f95f25).


* **What is the new behavior (if this is a feature change)?**
n/a, no feature changes.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
no


* **Other information**:

Release versioning of the aws-java-sdk package changed in
https://github.com/jenkinsci/aws-java-sdk-plugin/compare/aws-java-sdk-parent-1.12.80...1.12.89-292.v2712528e879c to no longer use a traditional semantic version, hence the long version name.