### PR TITLE
Remove gratuitous usage of Guice

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNDeleteStep.java
@@ -36,7 +36,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.inject.Inject;
 import java.time.Duration;
 import java.util.Set;
 
@@ -128,7 +127,6 @@ public class CFNDeleteStep extends Step {
 
 	public static class Execution extends SynchronousNonBlockingStepExecution<Void> {
 
-		@Inject
 		private transient CFNDeleteStep step;
 
 		public Execution(CFNDeleteStep step, StepContext context) {


### PR DESCRIPTION
Amends commit 1d123edfadb9f749e73f049024962c9584223ae4 from #52. That commit migrated away from the deprecated Guice subsystem but forgot to delete one of the Guice `@Inject` annotations.