### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/AWSIdentityStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSIdentityStep.java
@@ -25,8 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -40,6 +38,7 @@ import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
 
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
 
@@ -76,7 +75,7 @@ public class AWSIdentityStep extends Step {
 
 	public static class Execution extends SynchronousNonBlockingStepExecution<Map<String, String>> {
 
-		protected Execution(@Nonnull StepContext context) {
+		protected Execution(@NonNull StepContext context) {
 			super(context);
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/FileWrapper.java
+++ b/src/main/java/de/taimos/pipeline/aws/FileWrapper.java
@@ -52,10 +52,8 @@ package de.taimos.pipeline.aws;
 import java.io.IOException;
 import java.io.Serializable;
 
-import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.Whitelisted;
-
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 
 /**
@@ -67,15 +65,15 @@ public class FileWrapper implements Serializable {
 	private static final long serialVersionUID = 1L;
 	private static final String PATH_SUFFIX = "/";
 
-	@Nonnull
+	@NonNull
 	private final String name;
-	@Nonnull
+	@NonNull
 	private final String path;
 	private final boolean directory;
 	private final long length;
 	private final long lastModified;
 
-	public FileWrapper(@Nonnull String name, @Nonnull String path, boolean directory, long length, long lastModified) {
+	public FileWrapper(@NonNull String name, @NonNull String path, boolean directory, long length, long lastModified) {
 		this.name = name;
 		this.directory = directory;
 		this.length = length;
@@ -87,7 +85,7 @@ public class FileWrapper implements Serializable {
 		}
 	}
 
-	protected FileWrapper(@Nonnull FilePath base, @Nonnull FilePath file) throws IOException, InterruptedException {
+	protected FileWrapper(@NonNull FilePath base, @NonNull FilePath file) throws IOException, InterruptedException {
 		this(file.getName(),
 			file.getRemote().substring(base.getRemote().length() + 1),
 			file.isDirectory(),
@@ -96,18 +94,18 @@ public class FileWrapper implements Serializable {
 		);
 	}
 
-	protected FileWrapper(@Nonnull FilePath file) throws IOException, InterruptedException {
+	protected FileWrapper(@NonNull FilePath file) throws IOException, InterruptedException {
 		this(file.getName(), file.getRemote(), file.isDirectory(), file.length(), file.lastModified());
 	}
 
 	@Whitelisted
-	@Nonnull
+	@NonNull
 	public String getName() {
 		return this.name;
 	}
 
 	@Whitelisted
-	@Nonnull
+	@NonNull
 	public String getPath() {
 		return this.path;
 	}
@@ -129,7 +127,7 @@ public class FileWrapper implements Serializable {
 
 	@Override
 	@Whitelisted
-	@Nonnull
+	@NonNull
 	public String toString() {
 		return this.getPath();
 	}

--- a/src/main/java/de/taimos/pipeline/aws/PluginImpl.java
+++ b/src/main/java/de/taimos/pipeline/aws/PluginImpl.java
@@ -20,12 +20,11 @@
  */
 package de.taimos.pipeline.aws;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.ExtensionList;
 import static hudson.model.Descriptor.FormException;
 import jenkins.model.GlobalConfiguration;
-
-import javax.annotation.Nonnull;
 
 import net.sf.json.JSONObject;
 
@@ -73,7 +72,7 @@ public class PluginImpl extends GlobalConfiguration {
 	 *
 	 * @return the one.
 	 */
-	@Nonnull
+	@NonNull
 	public static PluginImpl getInstance() {
 		return ExtensionList.lookup(PluginImpl.class).get(0);
 	}

--- a/src/main/java/de/taimos/pipeline/aws/S3CopyStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3CopyStep.java
@@ -32,6 +32,7 @@ import com.amazonaws.services.s3.transfer.Copy;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.google.common.base.Preconditions;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -42,7 +43,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -176,7 +176,7 @@ public class S3CopyStep extends AbstractS3Step {
 		}
 
 		@Override
-		@Nonnull
+		@NonNull
 		public String getDisplayName() {
 			return "Copy file between S3 buckets";
 		}

--- a/src/main/java/de/taimos/pipeline/aws/S3DeleteStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/S3DeleteStep.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -40,6 +38,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.base.Preconditions;
 
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
 
@@ -216,7 +215,7 @@ public class S3DeleteStep extends AbstractS3Step {
 		}
 
 		@Override
-		public void stop(@Nonnull Throwable cause) throws Exception {
+		public void stop(@NonNull Throwable cause) throws Exception {
 			//
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/WithAWSStep.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.workflow.steps.BodyExecutionCallback;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -56,6 +54,7 @@ import de.taimos.pipeline.aws.utils.AssumedRole;
 import de.taimos.pipeline.aws.utils.AssumedRole.AssumeRole;
 import de.taimos.pipeline.aws.utils.IamRoleUtils;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Item;
@@ -308,7 +307,7 @@ public class WithAWSStep extends Step {
 			EnvironmentExpander expander = new EnvironmentExpander() {
 				private static final long serialVersionUID = 1L;
 				@Override
-				public void expand(@Nonnull EnvVars envVars) {
+				public void expand(@NonNull EnvVars envVars) {
 					envVars.overrideAll(awsEnv);
 				}
 			};
@@ -322,7 +321,7 @@ public class WithAWSStep extends Step {
 		private static final String ALLOW_ALL_POLICY = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"*\","
 				+ "\"Effect\":\"Allow\",\"Resource\":\"*\"}]}";
 
-		private void withFederatedUserId(@Nonnull EnvVars localEnv) {
+		private void withFederatedUserId(@NonNull EnvVars localEnv) {
 			if (!StringUtils.isNullOrEmpty(this.step.getFederatedUserId())) {
 				AWSSecurityTokenService sts = AWSClientFactory.create(AWSSecurityTokenServiceClientBuilder.standard(), this.getContext(), this.envVars);
 				GetFederationTokenRequest getFederationTokenRequest = new GetFederationTokenRequest();
@@ -341,7 +340,7 @@ public class WithAWSStep extends Step {
 
 		}
 
-		private void withCredentials(@Nonnull Run<?, ?> run, @Nonnull EnvVars localEnv) throws IOException, InterruptedException {
+		private void withCredentials(@NonNull Run<?, ?> run, @NonNull EnvVars localEnv) throws IOException, InterruptedException {
 			if (!StringUtils.isNullOrEmpty(this.step.getCredentials())) {
 				StandardUsernamePasswordCredentials usernamePasswordCredentials = CredentialsProvider.findCredentialById(this.step.getCredentials(),
 						StandardUsernamePasswordCredentials.class, run, Collections.emptyList());
@@ -378,7 +377,7 @@ public class WithAWSStep extends Step {
 			this.envVars.overrideAll(localEnv);
 		}
 
-		private void withRole(@Nonnull EnvVars localEnv) throws IOException, InterruptedException {
+		private void withRole(@NonNull EnvVars localEnv) throws IOException, InterruptedException {
 			if (!StringUtils.isNullOrEmpty(this.step.getRole())) {
 
 				AWSSecurityTokenService sts = AWSClientFactory.create(AWSSecurityTokenServiceClientBuilder.standard(), this.getContext(), this.envVars);
@@ -403,7 +402,7 @@ public class WithAWSStep extends Step {
 			}
 		}
 
-		private void withRegion(@Nonnull EnvVars localEnv) throws IOException, InterruptedException {
+		private void withRegion(@NonNull EnvVars localEnv) throws IOException, InterruptedException {
 			if (!StringUtils.isNullOrEmpty(this.step.getRegion())) {
 				this.getContext().get(TaskListener.class).getLogger().format("Setting AWS region %s %n ", this.step.getRegion());
 				localEnv.override(AWSClientFactory.AWS_DEFAULT_REGION, this.step.getRegion());
@@ -412,7 +411,7 @@ public class WithAWSStep extends Step {
 			}
 		}
 
-		private void withEndpointUrl(@Nonnull EnvVars localEnv) throws IOException, InterruptedException {
+		private void withEndpointUrl(@NonNull EnvVars localEnv) throws IOException, InterruptedException {
 			if (!StringUtils.isNullOrEmpty(this.step.getEndpointUrl())) {
 				this.getContext().get(TaskListener.class).getLogger().format("Setting AWS endpointUrl %s %n ", this.step.getEndpointUrl());
 				localEnv.override(AWSClientFactory.AWS_ENDPOINT_URL, this.step.getEndpointUrl());
@@ -420,7 +419,7 @@ public class WithAWSStep extends Step {
 			}
 		}
 
-		private void withProfile(@Nonnull EnvVars localEnv) throws IOException, InterruptedException {
+		private void withProfile(@NonNull EnvVars localEnv) throws IOException, InterruptedException {
 			if (!StringUtils.isNullOrEmpty(this.step.getProfile())) {
 				this.getContext().get(TaskListener.class).getLogger().format("Setting AWS profile %s %n ", this.step.getProfile());
 				localEnv.override(AWSClientFactory.AWS_DEFAULT_PROFILE, this.step.getProfile());

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/AbstractCFNCreateStep.java
@@ -32,6 +32,7 @@ import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.AWSUtilFactory;
 import de.taimos.pipeline.aws.cloudformation.parser.ParameterParser;
 import de.taimos.pipeline.aws.utils.IamRoleUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -39,7 +40,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 
@@ -79,7 +79,7 @@ abstract class AbstractCFNCreateStep extends TemplateStepBase {
 
 		private final transient C step;
 
-		protected Execution(C step, @Nonnull StepContext context) {
+		protected Execution(C step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNUpdateStep.java
@@ -25,8 +25,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -38,6 +36,7 @@ import com.amazonaws.services.cloudformation.model.RollbackConfiguration;
 import com.amazonaws.services.cloudformation.model.Tag;
 
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -87,7 +86,7 @@ public class CFNUpdateStep extends AbstractCFNCreateStep {
 
 	public static class Execution extends AbstractCFNCreateStep.Execution<CFNUpdateStep, Map<String, String>> {
 
-		protected Execution(CFNUpdateStep step, @Nonnull StepContext context) {
+		protected Execution(CFNUpdateStep step, @NonNull StepContext context) {
 			super(step, context);
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNValidateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CFNValidateStep.java
@@ -25,14 +25,13 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
 import com.amazonaws.services.cloudformation.model.ValidateTemplateResult;
 import com.amazonaws.services.cloudformation.model.transform.ValidateTemplateRequestMarshaller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.taimos.pipeline.aws.AwsSdkResponseToJson;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import groovy.json.JsonSlurper;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -109,7 +108,7 @@ public class CFNValidateStep extends Step {
 
 		private final transient CFNValidateStep step;
 
-		public Execution(CFNValidateStep step, @Nonnull StepContext context) {
+		public Execution(CFNValidateStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}
@@ -160,7 +159,7 @@ public class CFNValidateStep extends Step {
 		}
 
 		@Override
-		public void stop(@Nonnull Throwable cause) throws Exception {
+		public void stop(@NonNull Throwable cause) throws Exception {
 			//
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/AbstractCFNCreateStackSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/AbstractCFNCreateStackSetStep.java
@@ -33,6 +33,7 @@ import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.AWSUtilFactory;
 import de.taimos.pipeline.aws.cloudformation.TemplateStepBase;
 import de.taimos.pipeline.aws.cloudformation.parser.ParameterParser;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
@@ -40,7 +41,6 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 
@@ -98,7 +98,7 @@ abstract class AbstractCFNCreateStackSetStep extends TemplateStepBase {
 
 		protected abstract DescribeStackSetResult whenStackSetMissing(Collection<Parameter> parameters, Collection<Tag> tags) throws Exception;
 
-		protected Execution(C step, @Nonnull StepContext context) {
+		protected Execution(C step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNDeleteStackSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNDeleteStackSetStep.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.AWSUtilFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -37,7 +38,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class CFNDeleteStackSetStep extends Step {
@@ -77,7 +77,7 @@ public class CFNDeleteStackSetStep extends Step {
 		}
 
 		@Override
-		@Nonnull
+		@NonNull
 		public String getDisplayName() {
 			return "Delete CloudFormation Stack Set";
 		}
@@ -92,7 +92,7 @@ public class CFNDeleteStackSetStep extends Step {
 
 		private transient CFNDeleteStackSetStep step;
 
-		public Execution(CFNDeleteStackSetStep step, @Nonnull StepContext context) {
+		public Execution(CFNDeleteStackSetStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStep.java
@@ -30,6 +30,7 @@ import com.amazonaws.services.cloudformation.model.Tag;
 import com.amazonaws.services.cloudformation.model.UpdateStackSetRequest;
 import com.amazonaws.services.cloudformation.model.UpdateStackSetResult;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -37,7 +38,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +94,7 @@ public class CFNUpdateStackSetStep extends AbstractCFNCreateStackSetStep {
 
 	public static class Execution extends AbstractCFNCreateStackSetStep.Execution<CFNUpdateStackSetStep> {
 
-		protected Execution(CFNUpdateStackSetStep step, @Nonnull StepContext context) {
+		protected Execution(CFNUpdateStackSetStep step, @NonNull StepContext context) {
 			super(step, context);
 		}
 

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationStep.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationRequest;
 import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationResult;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -17,7 +18,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class EBCreateApplicationStep extends Step {
@@ -52,7 +52,7 @@ public class EBCreateApplicationStep extends Step {
 			return "ebCreateApplication";
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Creates a new Elastic Beanstalk application";
@@ -63,7 +63,7 @@ public class EBCreateApplicationStep extends Step {
 		private static final long serialVersionUID = 1L;
 		private final transient EBCreateApplicationStep step;
 
-		protected Execution(EBCreateApplicationStep step, @Nonnull StepContext context) {
+		protected Execution(EBCreateApplicationStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationVersionStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateApplicationVersionStep.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.elasticbeanstalk.model.CreateApplicationVersionRes
 import com.amazonaws.services.elasticbeanstalk.model.S3Location;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -18,7 +19,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class EBCreateApplicationVersionStep extends Step {
@@ -59,7 +59,7 @@ public class EBCreateApplicationVersionStep extends Step {
 			return "ebCreateApplicationVersion";
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Creates a new version for an elastic beanstalk application";
@@ -70,7 +70,7 @@ public class EBCreateApplicationVersionStep extends Step {
 		private static final long serialVersionUID = 1L;
 		private final transient EBCreateApplicationVersionStep step;
 
-		protected Execution(EBCreateApplicationVersionStep step, @Nonnull StepContext context) {
+		protected Execution(EBCreateApplicationVersionStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateConfigurationTemplateStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateConfigurationTemplateStep.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.elasticbeanstalk.model.CreateConfigurationTemplate
 import com.amazonaws.services.elasticbeanstalk.model.SourceConfiguration;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -18,7 +19,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class EBCreateConfigurationTemplateStep extends Step {
@@ -79,7 +79,7 @@ public class EBCreateConfigurationTemplateStep extends Step {
 			return "ebCreateConfigurationTemplate";
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Creates a new configuration template for an elastic beanstalk application";
@@ -90,7 +90,7 @@ public class EBCreateConfigurationTemplateStep extends Step {
 		private static final long serialVersionUID = 1L;
 		private final transient EBCreateConfigurationTemplateStep step;
 
-		protected Execution(EBCreateConfigurationTemplateStep step, @Nonnull StepContext context) {
+		protected Execution(EBCreateConfigurationTemplateStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBCreateEnvironmentStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBCreateEnvironmentStep.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest;
 import com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentResult;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -22,7 +23,6 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -85,7 +85,7 @@ public class EBCreateEnvironmentStep extends Step {
 			return "ebCreateEnvironment";
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Creates a new Elastic Beanstalk environment";
@@ -96,7 +96,7 @@ public class EBCreateEnvironmentStep extends Step {
 		private static final long serialVersionUID = 1L;
 		private final transient EBCreateEnvironmentStep step;
 
-		protected Execution(EBCreateEnvironmentStep step, @Nonnull StepContext context) {
+		protected Execution(EBCreateEnvironmentStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBSwapEnvironmentCNAMEsStep.java
@@ -10,6 +10,7 @@ import com.amazonaws.services.elasticbeanstalk.model.ResourceNotFoundException;
 import com.amazonaws.services.elasticbeanstalk.model.SwapEnvironmentCNAMEsRequest;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -21,7 +22,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class EBSwapEnvironmentCNAMEsStep extends Step {
@@ -84,7 +84,7 @@ public class EBSwapEnvironmentCNAMEsStep extends Step {
 			return "ebSwapEnvironmentCNAMEs";
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Swaps the CNAMEs of two elastic beanstalk environments.";
@@ -95,7 +95,7 @@ public class EBSwapEnvironmentCNAMEsStep extends Step {
 		private static final long serialVersionUID = 1L;
 		private final transient EBSwapEnvironmentCNAMEsStep step;
 
-		protected Execution(EBSwapEnvironmentCNAMEsStep step, @Nonnull StepContext context) {
+		protected Execution(EBSwapEnvironmentCNAMEsStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentHealthStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentHealthStep.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
 import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -19,7 +20,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Set;
 
@@ -63,7 +63,7 @@ public class EBWaitOnEnvironmentHealthStep extends Step {
 			return "ebWaitOnEnvironmentHealth";
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Waits until the specified environment application becomes available";
@@ -74,7 +74,7 @@ public class EBWaitOnEnvironmentHealthStep extends Step {
 		private static final long serialVersionUID = 1L;
 		private final transient EBWaitOnEnvironmentHealthStep step;
 
-		protected Execution(EBWaitOnEnvironmentHealthStep step, @Nonnull StepContext context) {
+		protected Execution(EBWaitOnEnvironmentHealthStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentStatusStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/eb/EBWaitOnEnvironmentStatusStep.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsResult;
 import com.amazonaws.services.elasticbeanstalk.model.EnvironmentDescription;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.TaskListener;
@@ -19,7 +20,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.Set;
 
@@ -57,7 +57,7 @@ public class EBWaitOnEnvironmentStatusStep extends Step {
 			return "ebWaitOnEnvironmentStatus";
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getDisplayName() {
 			return "Waits until the specified environment becomes available";
@@ -68,7 +68,7 @@ public class EBWaitOnEnvironmentStatusStep extends Step {
 		private static final long serialVersionUID = 1L;
 		private final transient EBWaitOnEnvironmentStatusStep step;
 
-		protected Execution(EBWaitOnEnvironmentStatusStep step, @Nonnull StepContext context) {
+		protected Execution(EBWaitOnEnvironmentStatusStep step, @NonNull StepContext context) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/ecr/ECRDeleteImagesStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/ecr/ECRDeleteImagesStep.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.ecr.model.ImageFailure;
 import com.amazonaws.services.ecr.model.ImageIdentifier;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.workflow.steps.Step;
@@ -18,7 +19,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -77,7 +77,7 @@ public class ECRDeleteImagesStep extends Step {
 		}
 
 		@Override
-		@Nonnull
+		@NonNull
 		public String getDisplayName() {
 			return "Delete ecr images";
 		}
@@ -92,7 +92,7 @@ public class ECRDeleteImagesStep extends Step {
 
 		private transient ECRDeleteImagesStep step;
 
-		public Execution(@Nonnull StepContext context, ECRDeleteImagesStep step) {
+		public Execution(@NonNull StepContext context, ECRDeleteImagesStep step) {
 			super(context);
 			this.step = step;
 		}

--- a/src/main/java/de/taimos/pipeline/aws/ecr/ECRListImagesStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/ecr/ECRListImagesStep.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.ecr.model.ListImagesRequest;
 import com.amazonaws.services.ecr.model.ListImagesResult;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -16,7 +17,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -78,7 +78,7 @@ public class ECRListImagesStep extends Step {
 		}
 
 		@Override
-		@Nonnull
+		@NonNull
 		public String getDisplayName() {
 			return "List ECR Images";
 		}

--- a/src/main/java/de/taimos/pipeline/aws/ecr/ECRSetRepositoryPolicyStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/ecr/ECRSetRepositoryPolicyStep.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.ecr.model.SetRepositoryPolicyRequest;
 import com.amazonaws.services.ecr.model.SetRepositoryPolicyResult;
 import de.taimos.pipeline.aws.AWSClientFactory;
 import de.taimos.pipeline.aws.utils.StepUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -15,7 +16,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.util.Set;
 
 public class ECRSetRepositoryPolicyStep extends Step {
@@ -69,7 +69,7 @@ public class ECRSetRepositoryPolicyStep extends Step {
 		}
 
 		@Override
-		@Nonnull
+		@NonNull
 		public String getDisplayName() {
 			return "Set ECR Repository Policy";
 		}


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [x] Tests for the changes have been added if possible (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Changes are mentioned in the changelog (for bug fixes / features) (not needed - behavior preserving change)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the tutorial.

* **What is the current behavior?** (You can also link to an open issue here)

Confirmed that automated tests pass on Linux with Java 21.

* **What is the new behavior (if this is a feature change)?**

Confirmed that automated tests pass on Linux with Java 21.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)

No breaking change.

* **Other information**:

Not applicable
