### PR TITLE
Make configurable via environment variables socket timeout and retries in SDK client

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
@@ -54,6 +54,8 @@ public class AWSClientFactory implements Serializable {
 	static final String AWS_DEFAULT_REGION = "AWS_DEFAULT_REGION";
 	static final String AWS_REGION = "AWS_REGION";
 	static final String AWS_ENDPOINT_URL = "AWS_ENDPOINT_URL";
+	static final String AWS_SDK_SOCKET_TIMEOUT = "AWS_SDK_SOCKET_TIMEOUT";
+	static final String AWS_SDK_RETRIES = "AWS_SDK_RETRIES";
 	static final String AWS_PIPELINE_STEPS_FROM_NODE = "AWS_PIPELINE_STEPS_FROM_NODE";
 	private static AWSClientFactoryDelegate factoryDelegate;
 
@@ -102,8 +104,15 @@ public class AWSClientFactory implements Serializable {
 
 	private static ClientConfiguration getClientConfiguration(EnvVars vars) {
 		ClientConfiguration clientConfiguration = new ClientConfiguration();
-		//the default max retry is 3. Increasing this to be more resilient to upstream errors
-		clientConfiguration.setRetryPolicy(new RetryPolicy(null, null, 10, false));
+
+		// The default SDK max retry is 3, increasing this to be more resilient to upstream errors
+		Integer retries = Integer.valueOf(vars.get(AWS_SDK_RETRIES, "10"));
+		clientConfiguration.setRetryPolicy(new RetryPolicy(null, null, retries, false));
+
+		// The default SDK socket timeout is 50000, use as deafult and allow to override via environment variable
+		Integer socketTimeout = Integer.valueOf(vars.get(AWS_SDK_SOCKET_TIMEOUT, "50000"));
+		clientConfiguration.setSocketTimeout(socketTimeout);
+
 		ProxyConfiguration.configure(vars, clientConfiguration);
 		return clientConfiguration;
 	}

--- a/src/test/java/de/taimos/pipeline/aws/WithAWSStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/WithAWSStepTest.java
@@ -294,7 +294,7 @@ public class WithAWSStepTest {
 		jenkinsRule.waitForCompletion(workflowRun);
 		jenkinsRule.assertBuildStatus(Result.FAILURE, workflowRun);
 		jenkinsRule.assertLogContains("Requesting assume role", workflowRun);
-		jenkinsRule.assertLogContains("Invalid base64 SAMLResponse", workflowRun);
+		jenkinsRule.assertLogContains("Specified provider doesn't exist", workflowRun);
 	}
 
 	@Test


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message describes your change
- [ ] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
In case if `invokeLambda` takes more than the default SDK timeout (50 seconds), the pipeline will make more retries instead of waiting a bit longer.


* **What is the current behavior?** (You can also link to an open issue here)
The changes to fix the issue described in https://github.com/jenkinsci/pipeline-aws-plugin/issues/208


* **What is the new behavior (if this is a feature change)?**
By doing this change SDK client timeout could be overriden via environment variable `AWS_SDK_SOCKET_TIMEOUT` in case if a target lambda function is supposed to run longer than default 50 seconds. The number of retries could be also configured via `AWS_SDK_RETRIES` environment variable in case if a client does not want to make retries and would prefer to fail pipeline in case of timeout exceeded.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No.


* **Other information**:
Would like to get a confirmation that using `EnvVars` class methods allow to read environment variables provided in a Jenkins pipeline code, to make sure this is not any kind of internal Jenkins environment variables or anything else.
Did not find any documentation with supported environment variables, please point me if such documentation exists and needs to be updated.