### PR TITLE
feat: add RegionConcurrencyType to CloudFormation Update StackSet Operation Preferences

### DIFF
--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/JenkinsStackSetOperationPreferences.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/stacksets/JenkinsStackSetOperationPreferences.java
@@ -42,4 +42,10 @@ public class JenkinsStackSetOperationPreferences extends StackSetOperationPrefer
 	public void setMaxConcurrentPercentage(Integer maxConcurrentPercentage) {
 		super.setMaxConcurrentPercentage(maxConcurrentPercentage);
 	}
+
+	@DataBoundSetter
+	@Override
+	public void setRegionConcurrencyType(String regionConcurrencyType) {
+		super.setRegionConcurrencyType(regionConcurrencyType);
+	}
 }

--- a/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStepTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/cloudformation/stacksets/CFNUpdateStackSetStepTest.java
@@ -121,7 +121,7 @@ public class CFNUpdateStackSetStepTest {
 				);
 		job.setDefinition(new CpsFlowDefinition(""
 				+ "node {\n"
-				+ "  cfnUpdateStackSet(stackSet: 'foo', operationPreferences: [failureToleranceCount: 5, regionOrder: ['us-west-2'], failureTolerancePercentage: 17, maxConcurrentCount: 18, maxConcurrentPercentage: 34])"
+				+ "  cfnUpdateStackSet(stackSet: 'foo', operationPreferences: [failureToleranceCount: 5, regionOrder: ['us-west-2'], failureTolerancePercentage: 17, maxConcurrentCount: 18, maxConcurrentPercentage: 34, regionConcurrencyType: 'SEQUENTIAL'])"
 				+ "}\n", true)
 		);
 		jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
@@ -135,6 +135,7 @@ public class CFNUpdateStackSetStepTest {
 				.withFailureTolerancePercentage(17)
 				.withMaxConcurrentCount(18)
 				.withMaxConcurrentPercentage(34)
+				.withRegionConcurrencyType("SEQUENTIAL")
 		);
 
 		Mockito.verify(stackSet).waitForOperationToComplete(operationId, Duration.ofSeconds(1));


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message describes your change
- [X] Tests for the changes have been added if possible (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Changes are mentioned in the changelog (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This feature adds new functionality.


* **What is the current behavior?** (You can also link to an open issue here)
The current behavior does not recognize RegionConcurrencyType as a CloudFormation StackSet Operation Preference.


* **What is the new behavior (if this is a feature change)?**
This change adds the ability to provide RegionConcurrencyType of 'PARALLEL' or 'SEQUENTIAL' for the CloudFormation StackSet Operation Preferences.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their setup due to this PR?)
No


* **Other information**: