### PR TITLE
Remove commons-lang2 usages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.80</version>
+        <version>6.2116.v7501b_67dc517</version>
         <relativePath />
     </parent>
     <groupId>de.taimos</groupId>
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>2928.ved44ea_84e034</version>
+                <version>5054.v620b_5d2b_d5e6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -79,9 +79,10 @@
         <revision>1.46</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.414</jenkins.baseline>
+        <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
     <build>
     <plugins>
@@ -193,6 +194,10 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>snakeyaml-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,10 +196,6 @@
             <artifactId>snakeyaml-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.jenkins.plugins</groupId>
-            <artifactId>commons-lang3-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
             <version>2.12.0</version>

--- a/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
@@ -35,7 +35,7 @@ import com.amazonaws.retry.RetryPolicy;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;

--- a/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
+++ b/src/main/java/de/taimos/pipeline/aws/AWSClientFactory.java
@@ -35,7 +35,6 @@ import com.amazonaws.retry.RetryPolicy;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.model.TaskListener;
-import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -90,8 +89,9 @@ public class AWSClientFactory implements Serializable {
 		if (clientBuilder == null) {
 			throw new IllegalArgumentException("ClientBuilder must not be null");
 		}
-		if (StringUtils.isNotBlank(vars.get(AWS_ENDPOINT_URL))) {
-			clientBuilder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(vars.get(AWS_ENDPOINT_URL), vars.get(AWS_REGION)));
+		String endpointUrl = vars.get(AWS_ENDPOINT_URL);
+		if (endpointUrl != null && !endpointUrl.isBlank()) {
+			clientBuilder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpointUrl, vars.get(AWS_REGION)));
 		} else {
 			clientBuilder.setRegion(AWSClientFactory.getRegion(vars).getName());
 		}

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -21,6 +21,7 @@
 
 package de.taimos.pipeline.aws.cloudformation;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
 import com.amazonaws.services.cloudformation.model.Capability;
@@ -121,6 +122,7 @@ public class CloudFormationStack {
 		return map;
 	}
 
+	@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE") // Lombok getTimeout() check
 	public Map<String, String> create(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, Collection<String> notificationARNs, PollConfiguration pollConfiguration, String roleArn, String onFailure, Boolean enableTerminationProtection) throws ExecutionException {
 		if ((templateBody == null || templateBody.isEmpty()) && (templateUrl == null || templateUrl.isEmpty())) {
 			throw new IllegalArgumentException("Either a file or url for the template must be specified");

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/CloudFormationStack.java
@@ -21,7 +21,6 @@
 
 package de.taimos.pipeline.aws.cloudformation;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
 import com.amazonaws.services.cloudformation.model.Capability;
@@ -122,7 +121,6 @@ public class CloudFormationStack {
 		return map;
 	}
 
-	@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE") // Lombok getTimeout() check
 	public Map<String, String> create(String templateBody, String templateUrl, Collection<Parameter> params, Collection<Tag> tags, Collection<String> notificationARNs, PollConfiguration pollConfiguration, String roleArn, String onFailure, Boolean enableTerminationProtection) throws ExecutionException {
 		if ((templateBody == null || templateBody.isEmpty()) && (templateUrl == null || templateUrl.isEmpty())) {
 			throw new IllegalArgumentException("Either a file or url for the template must be specified");
@@ -131,7 +129,7 @@ public class CloudFormationStack {
 		CreateStackRequest req = new CreateStackRequest();
 		req.withStackName(this.stack).withCapabilities(Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM, Capability.CAPABILITY_AUTO_EXPAND).withEnableTerminationProtection(enableTerminationProtection);
 		req.withTemplateBody(templateBody).withTemplateURL(templateUrl).withParameters(params).withTags(tags).withNotificationARNs(notificationARNs)
-				.withTimeoutInMinutes(pollConfiguration.getTimeout() == null ? null : (int) pollConfiguration.getTimeout().toMinutes())
+				.withTimeoutInMinutes((int) pollConfiguration.getTimeout().toMinutes())
 				.withRoleARN(roleArn)
 				.withOnFailure(OnFailure.valueOf(onFailure));
 		this.client.createStack(req);

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
@@ -30,7 +30,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.concurrent.BasicFuture;
 
 import com.amazonaws.AmazonWebServiceRequest;
@@ -50,7 +50,7 @@ import com.amazonaws.waiters.WaiterParameters;
 import de.taimos.pipeline.aws.cloudformation.utils.TimeOutRetryStrategy;
 import hudson.model.TaskListener;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.concurrent.BasicFuture;
 
 import java.text.SimpleDateFormat;

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/EventPrinter.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.concurrent.BasicFuture;
 
 import com.amazonaws.AmazonWebServiceRequest;
@@ -49,16 +48,6 @@ import com.amazonaws.waiters.WaiterParameters;
 
 import de.taimos.pipeline.aws.cloudformation.utils.TimeOutRetryStrategy;
 import hudson.model.TaskListener;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.concurrent.BasicFuture;
-
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 class EventPrinter {
 
@@ -173,7 +162,7 @@ class EventPrinter {
 	}
 
 	private void printLine() {
-		this.listener.getLogger().println(StringUtils.repeat("-", 231));
+		this.listener.getLogger().println("-".repeat(231));
 	}
 
 	private void printStackName(String stackName) {

--- a/src/main/java/de/taimos/pipeline/aws/cloudformation/PollConfiguration.java
+++ b/src/main/java/de/taimos/pipeline/aws/cloudformation/PollConfiguration.java
@@ -1,13 +1,14 @@
 package de.taimos.pipeline.aws.cloudformation;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
-
 import java.time.Duration;
 
 @Value
 @Builder(toBuilder = true)
+@SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE") // Lombok @NonNull check
 public class PollConfiguration {
 
 	public static final PollConfiguration DEFAULT = builder()

--- a/src/main/java/de/taimos/pipeline/aws/code/deploy/CreateDeployStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/code/deploy/CreateDeployStep.java
@@ -17,7 +17,7 @@ import de.taimos.pipeline.aws.utils.StepUtils;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import lombok.Getter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;

--- a/src/main/java/de/taimos/pipeline/aws/code/deploy/CreateDeployStep.java
+++ b/src/main/java/de/taimos/pipeline/aws/code/deploy/CreateDeployStep.java
@@ -17,7 +17,6 @@ import de.taimos.pipeline.aws.utils.StepUtils;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import lombok.Getter;
-import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -186,7 +185,7 @@ public class CreateDeployStep extends Step {
 			if (isEcsOrLambdaDeployment()) {
 				return null;
 			}
-			if (StringUtils.isEmpty(fileExistsBehavior)) {
+			if (fileExistsBehavior == null || fileExistsBehavior.isEmpty()) {
 				return FileExistsBehavior.DISALLOW;
 			}
 			return FileExistsBehavior.fromValue(fileExistsBehavior);
@@ -214,7 +213,7 @@ public class CreateDeployStep extends Step {
 		}
 
 		private RevisionLocation getRevisionLocation() {
-			if (StringUtils.isNotEmpty(step.getS3Bucket())) {
+			if (step.getS3Bucket() != null && !step.getS3Bucket().isEmpty()) {
 				final S3Location s3Location = new S3Location().withBucket(step.getS3Bucket())
 						.withKey(step.getS3Key())
 						.withBundleType(step.getS3BundleType());

--- a/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
@@ -39,7 +39,7 @@ public class RoleSessionNameBuilderTest {
 
 	@Test
 	public void nameLongerThanAWSLimitAreStripped() {
-		String jobName = org.apache.commons.lang3.StringUtils.repeat("s", 64);
+		String jobName = "s".repeat(64);
 		String buildNumber = "123";
 		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder.withJobName(jobName)
 				.withBuildNumber(buildNumber);
@@ -49,7 +49,7 @@ public class RoleSessionNameBuilderTest {
 
 	@Test
 	public void nameEqualToAWSLimitAreStripped() {
-		String jobName = org.apache.commons.lang3.StringUtils.repeat("s", 52);
+		String jobName = "s".repeat(52);
 		String buildNumber = "123";
 		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder.withJobName(jobName)
 				.withBuildNumber(buildNumber);

--- a/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
+++ b/src/test/java/de/taimos/pipeline/aws/RoleSessionNameBuilderTest.java
@@ -39,7 +39,7 @@ public class RoleSessionNameBuilderTest {
 
 	@Test
 	public void nameLongerThanAWSLimitAreStripped() {
-		String jobName = org.apache.commons.lang.StringUtils.repeat("s", 64);
+		String jobName = org.apache.commons.lang3.StringUtils.repeat("s", 64);
 		String buildNumber = "123";
 		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder.withJobName(jobName)
 				.withBuildNumber(buildNumber);
@@ -49,7 +49,7 @@ public class RoleSessionNameBuilderTest {
 
 	@Test
 	public void nameEqualToAWSLimitAreStripped() {
-		String jobName = org.apache.commons.lang.StringUtils.repeat("s", 52);
+		String jobName = org.apache.commons.lang3.StringUtils.repeat("s", 52);
 		String buildNumber = "123";
 		final RoleSessionNameBuilder roleSessionNameBuilder = RoleSessionNameBuilder.withJobName(jobName)
 				.withBuildNumber(buildNumber);


### PR DESCRIPTION
Preparing for commons-lang2 removal https://github.com/jenkinsci/jenkins/pull/26105, usages are simple here so use JDK apis directly.

This PR builds on top of https://github.com/jenkinsci/pipeline-aws-plugin/pull/344

**Testing**

`mvn compile` after ban commons-lang2.